### PR TITLE
feat: Add smart context menus for pin numbers in code editor

### DIFF
--- a/arduino_ide/ui/code_editor.py
+++ b/arduino_ide/ui/code_editor.py
@@ -4,12 +4,13 @@ Code editor with syntax highlighting and IntelliSense
 
 from PySide6.QtWidgets import (
     QPlainTextEdit, QWidget, QTextEdit, QCompleter, QLabel, QHBoxLayout,
-    QVBoxLayout, QScrollBar, QToolTip
+    QVBoxLayout, QScrollBar, QToolTip, QMenu, QDialog, QFormLayout, QPushButton,
+    QListWidget, QListWidgetItem, QTextBrowser, QDialogButtonBox
 )
 from PySide6.QtCore import Qt, QRect, QSize, Signal, QStringListModel, QTimer, QPoint
 from PySide6.QtGui import (
     QColor, QPainter, QTextFormat, QFont, QSyntaxHighlighter,
-    QTextCharFormat, QPalette, QTextCursor, QPainterPath, QPen, QBrush
+    QTextCharFormat, QPalette, QTextCursor, QPainterPath, QPen, QBrush, QAction
 )
 import re
 from pathlib import Path
@@ -651,3 +652,559 @@ class CodeEditor(QPlainTextEdit):
             QToolTip.hideText()
 
         super().mouseMoveEvent(event)
+
+    def contextMenuEvent(self, event):
+        """Show context menu with pin-specific actions"""
+        # Get word under cursor
+        cursor = self.cursorForPosition(event.pos())
+        cursor.select(QTextCursor.WordUnderCursor)
+        word = cursor.selectedText()
+
+        # Check if word is a pin number or identifier
+        pin_info = self.detect_pin_under_cursor(cursor)
+
+        if pin_info:
+            # Create pin-specific context menu
+            menu = QMenu(self)
+
+            # Add separator with pin name
+            pin_label = menu.addAction(f"Pin: {pin_info['display_name']}")
+            pin_label.setEnabled(False)
+            menu.addSeparator()
+
+            # View in Pinout Diagram
+            view_action = QAction("View in Pinout Diagram", self)
+            view_action.triggered.connect(lambda: self.view_pin_diagram(pin_info))
+            menu.addAction(view_action)
+
+            # Show Pin Capabilities
+            capabilities_action = QAction("Show Pin Capabilities", self)
+            capabilities_action.triggered.connect(lambda: self.show_pin_capabilities(pin_info))
+            menu.addAction(capabilities_action)
+
+            # Find Other Uses
+            find_uses_action = QAction("Find Other Uses", self)
+            find_uses_action.triggered.connect(lambda: self.find_pin_uses(pin_info))
+            menu.addAction(find_uses_action)
+
+            menu.addSeparator()
+
+            # Generate pinMode() submenu
+            pinmode_menu = QMenu("Generate pinMode()", self)
+
+            input_action = QAction("INPUT", self)
+            input_action.triggered.connect(lambda: self.generate_pinmode(pin_info, "INPUT"))
+            pinmode_menu.addAction(input_action)
+
+            output_action = QAction("OUTPUT", self)
+            output_action.triggered.connect(lambda: self.generate_pinmode(pin_info, "OUTPUT"))
+            pinmode_menu.addAction(output_action)
+
+            input_pullup_action = QAction("INPUT_PULLUP", self)
+            input_pullup_action.triggered.connect(lambda: self.generate_pinmode(pin_info, "INPUT_PULLUP"))
+            pinmode_menu.addAction(input_pullup_action)
+
+            menu.addMenu(pinmode_menu)
+
+            # Show the menu
+            menu.exec_(event.globalPos())
+        else:
+            # Show standard context menu
+            menu = self.createStandardContextMenu()
+            menu.exec_(event.globalPos())
+
+    def detect_pin_under_cursor(self, cursor):
+        """Detect if cursor is on a pin number or identifier
+
+        Returns dict with pin info or None if not a pin
+        """
+        # Select word under cursor
+        cursor.select(QTextCursor.WordUnderCursor)
+        word = cursor.selectedText()
+
+        if not word:
+            return None
+
+        # Check if it's a numeric pin (0-13 for digital, 14-19 for analog)
+        if word.isdigit():
+            pin_num = int(word)
+            if 0 <= pin_num <= 19:
+                display_name = f"D{pin_num}" if pin_num < 14 else f"A{pin_num - 14}"
+                return {
+                    'raw': word,
+                    'display_name': display_name,
+                    'pin_number': pin_num,
+                    'type': 'digital' if pin_num < 14 else 'analog'
+                }
+
+        # Check for analog pins (A0-A7)
+        if re.match(r'^A[0-7]$', word):
+            return {
+                'raw': word,
+                'display_name': word,
+                'pin_number': int(word[1:]) + 14,
+                'type': 'analog'
+            }
+
+        # Check for special pin names
+        special_pins = {
+            'LED_BUILTIN': {'display_name': 'D13 (LED_BUILTIN)', 'pin_number': 13, 'type': 'digital'},
+            'SCL': {'display_name': 'A5 (SCL)', 'pin_number': 19, 'type': 'i2c'},
+            'SDA': {'display_name': 'A4 (SDA)', 'pin_number': 18, 'type': 'i2c'},
+            'SS': {'display_name': 'D10 (SS)', 'pin_number': 10, 'type': 'spi'},
+            'MOSI': {'display_name': 'D11 (MOSI)', 'pin_number': 11, 'type': 'spi'},
+            'MISO': {'display_name': 'D12 (MISO)', 'pin_number': 12, 'type': 'spi'},
+            'SCK': {'display_name': 'D13 (SCK)', 'pin_number': 13, 'type': 'spi'},
+        }
+
+        if word in special_pins:
+            info = special_pins[word].copy()
+            info['raw'] = word
+            return info
+
+        # Check if it's a variable that might be assigned a pin number
+        # Look backwards in the code for assignments like "int ledPin = 13;"
+        text = self.toPlainText()
+        # Pattern: variable declaration with pin assignment
+        pattern = rf'\b(?:const\s+)?(?:int|byte)\s+{re.escape(word)}\s*=\s*(\d+|A[0-7]|LED_BUILTIN)\b'
+        match = re.search(pattern, text)
+
+        if match:
+            assigned_value = match.group(1)
+            # Recursively detect what the assigned value is
+            temp_cursor = QTextCursor(self.document())
+            temp_cursor.movePosition(QTextCursor.Start)
+            temp_cursor.movePosition(QTextCursor.Right, QTextCursor.MoveAnchor, match.start(1))
+            temp_cursor.movePosition(QTextCursor.Right, QTextCursor.KeepAnchor, len(assigned_value))
+
+            result = self.detect_pin_under_cursor(temp_cursor)
+            if result:
+                result['variable_name'] = word
+                return result
+
+        return None
+
+    def view_pin_diagram(self, pin_info):
+        """Show pin in pinout diagram"""
+        dialog = PinDiagramDialog(pin_info, self)
+        dialog.exec_()
+
+    def show_pin_capabilities(self, pin_info):
+        """Show pin capabilities dialog"""
+        dialog = PinCapabilitiesDialog(pin_info, self)
+        dialog.exec_()
+
+    def find_pin_uses(self, pin_info):
+        """Find and highlight all uses of this pin in the code"""
+        # Get all text
+        text = self.toPlainText()
+
+        # Create search terms (pin number, variable name, etc.)
+        search_terms = [pin_info['raw']]
+        if 'variable_name' in pin_info:
+            search_terms.append(pin_info['variable_name'])
+
+        # Find all occurrences
+        occurrences = []
+        for term in search_terms:
+            pattern = r'\b' + re.escape(term) + r'\b'
+            for match in re.finditer(pattern, text):
+                line_num = text[:match.start()].count('\n') + 1
+                occurrences.append((line_num, match.start(), match.end(), term))
+
+        if occurrences:
+            # Show results in a dialog
+            dialog = PinUsesDialog(pin_info, occurrences, self)
+            result = dialog.exec_()
+
+            # If user clicked on a usage, jump to it
+            if result and hasattr(dialog, 'selected_position'):
+                cursor = QTextCursor(self.document())
+                cursor.setPosition(dialog.selected_position)
+                self.setTextCursor(cursor)
+                self.centerCursor()
+        else:
+            # No uses found
+            QToolTip.showText(self.mapToGlobal(self.cursorRect().center()),
+                            f"No uses of {pin_info['display_name']} found", self)
+
+    def generate_pinmode(self, pin_info, mode):
+        """Generate pinMode() statement at cursor position"""
+        # Determine what identifier to use
+        if 'variable_name' in pin_info:
+            pin_identifier = pin_info['variable_name']
+        else:
+            pin_identifier = pin_info['raw']
+
+        # Generate the pinMode statement
+        pinmode_statement = f"pinMode({pin_identifier}, {mode});"
+
+        # Insert at cursor position
+        cursor = self.textCursor()
+
+        # Find the setup() function or insert at cursor
+        text = self.toPlainText()
+        setup_match = re.search(r'void\s+setup\s*\(\s*\)\s*\{', text)
+
+        if setup_match:
+            # Insert after the opening brace of setup()
+            insert_pos = setup_match.end()
+
+            # Find the indentation
+            lines = text[:insert_pos].split('\n')
+            last_line = lines[-1] if lines else ''
+            indent = '  '  # Default 2 spaces
+
+            # Insert the pinMode statement
+            cursor.setPosition(insert_pos)
+            cursor.insertText(f'\n{indent}{pinmode_statement}')
+        else:
+            # Insert at current cursor position
+            cursor.insertText(pinmode_statement)
+
+        # Move cursor after inserted text
+        self.setTextCursor(cursor)
+
+
+class PinDiagramDialog(QDialog):
+    """Dialog showing Arduino pin diagram with highlighted pin"""
+
+    def __init__(self, pin_info, parent=None):
+        super().__init__(parent)
+        self.pin_info = pin_info
+        self.setWindowTitle("Arduino Pinout Diagram")
+        self.setMinimumSize(600, 500)
+        self.setup_ui()
+
+    def setup_ui(self):
+        """Setup the dialog UI"""
+        layout = QVBoxLayout(self)
+
+        # Header
+        header = QLabel(f"Pin: {self.pin_info['display_name']}")
+        header.setStyleSheet("""
+            QLabel {
+                font-size: 16px;
+                font-weight: bold;
+                padding: 10px;
+                background-color: #2d2d2d;
+                color: #ffffff;
+            }
+        """)
+        layout.addWidget(header)
+
+        # Create Arduino Uno pinout diagram (simplified ASCII art version)
+        diagram = self.create_pinout_diagram()
+        diagram_label = QLabel(diagram)
+        diagram_label.setFont(QFont("Courier New", 10))
+        diagram_label.setStyleSheet("""
+            QLabel {
+                background-color: #1e1e1e;
+                color: #d4d4d4;
+                padding: 20px;
+                border: 1px solid #3e3e42;
+            }
+        """)
+        diagram_label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(diagram_label)
+
+        # Close button
+        button_box = QDialogButtonBox(QDialogButtonBox.Ok)
+        button_box.accepted.connect(self.accept)
+        layout.addWidget(button_box)
+
+    def create_pinout_diagram(self):
+        """Create ASCII art pinout diagram with highlighted pin"""
+        pin_num = self.pin_info['pin_number']
+
+        # Arduino Uno pinout (simplified)
+        diagram_lines = [
+            "┌─────────────────────────────────────────────────┐",
+            "│           Arduino Uno R3 Pinout                 │",
+            "├─────────────────────────────────────────────────┤",
+            "│                                                 │",
+            "│  Digital I/O:                                   │",
+            "│  ┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐     │",
+            "│  │ 0 │ 1 │ 2 │ 3 │ 4 │ 5 │ 6 │ 7 │ 8 │ 9 │     │",
+            "│  └───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘     │",
+            "│  ┌────┬────┬────┬────┐                         │",
+            "│  │ 10 │ 11 │ 12 │ 13 │                         │",
+            "│  └────┴────┴────┴────┘                         │",
+            "│                                                 │",
+            "│  Analog Inputs:                                 │",
+            "│  ┌────┬────┬────┬────┬────┬────┐               │",
+            "│  │ A0 │ A1 │ A2 │ A3 │ A4 │ A5 │               │",
+            "│  └────┴────┴────┴────┴────┴────┘               │",
+            "│                                                 │",
+            "│  Special Functions:                             │",
+            "│  • Pins 0-1: Serial (RX/TX)                     │",
+            "│  • Pins 2-3: External Interrupts                │",
+            "│  • Pins 3,5,6,9,10,11: PWM                      │",
+            "│  • Pin 13: Built-in LED                         │",
+            "│  • A4-A5: I2C (SDA/SCL)                         │",
+            "│  • Pins 10-13: SPI (SS/MOSI/MISO/SCK)           │",
+            "│                                                 │",
+            "└─────────────────────────────────────────────────┘"
+        ]
+
+        # Highlight the selected pin
+        highlighted = []
+        for line in diagram_lines:
+            if pin_num < 14:
+                # Digital pin
+                pin_str = str(pin_num)
+                if f' {pin_str} ' in line or f'│ {pin_str} │' in line:
+                    line = line.replace(f' {pin_str} ', f'[{pin_str}]')
+                    line = line.replace(f'│ {pin_str} │', f'│[{pin_str}]│')
+            else:
+                # Analog pin
+                pin_str = f'A{pin_num - 14}'
+                if f' {pin_str} ' in line or f'│ {pin_str} │' in line:
+                    line = line.replace(f' {pin_str} ', f'[{pin_str}]')
+                    line = line.replace(f'│ {pin_str} │', f'│[{pin_str}]│')
+
+            highlighted.append(line)
+
+        return '\n'.join(highlighted)
+
+
+class PinCapabilitiesDialog(QDialog):
+    """Dialog showing detailed pin capabilities"""
+
+    def __init__(self, pin_info, parent=None):
+        super().__init__(parent)
+        self.pin_info = pin_info
+        self.setWindowTitle("Pin Capabilities")
+        self.setMinimumSize(500, 400)
+        self.setup_ui()
+
+    def setup_ui(self):
+        """Setup the dialog UI"""
+        layout = QVBoxLayout(self)
+
+        # Header
+        header = QLabel(f"Capabilities of {self.pin_info['display_name']}")
+        header.setStyleSheet("""
+            QLabel {
+                font-size: 16px;
+                font-weight: bold;
+                padding: 10px;
+                background-color: #2d2d2d;
+                color: #ffffff;
+            }
+        """)
+        layout.addWidget(header)
+
+        # Capabilities content
+        capabilities = self.get_pin_capabilities()
+        content = QTextBrowser()
+        content.setHtml(capabilities)
+        content.setStyleSheet("""
+            QTextBrowser {
+                background-color: #1e1e1e;
+                color: #d4d4d4;
+                border: 1px solid #3e3e42;
+                padding: 10px;
+            }
+        """)
+        layout.addWidget(content)
+
+        # Close button
+        button_box = QDialogButtonBox(QDialogButtonBox.Ok)
+        button_box.accepted.connect(self.accept)
+        layout.addWidget(button_box)
+
+    def get_pin_capabilities(self):
+        """Get HTML formatted pin capabilities"""
+        pin_num = self.pin_info['pin_number']
+        pin_type = self.pin_info['type']
+
+        # Define capabilities for each pin
+        capabilities = {
+            'basic': ['Digital I/O (INPUT/OUTPUT/INPUT_PULLUP)'],
+            'pwm': [],
+            'analog': [],
+            'special': []
+        }
+
+        # Digital pins
+        if pin_num < 14:
+            # PWM capable pins
+            if pin_num in [3, 5, 6, 9, 10, 11]:
+                capabilities['pwm'].append('PWM Output (analogWrite)')
+
+            # Serial
+            if pin_num == 0:
+                capabilities['special'].append('Serial RX (receive)')
+            elif pin_num == 1:
+                capabilities['special'].append('Serial TX (transmit)')
+
+            # External interrupts
+            if pin_num in [2, 3]:
+                capabilities['special'].append(f'External Interrupt INT{pin_num - 2}')
+
+            # SPI
+            if pin_num == 10:
+                capabilities['special'].append('SPI SS (Slave Select)')
+            elif pin_num == 11:
+                capabilities['special'].append('SPI MOSI (Master Out Slave In)')
+            elif pin_num == 12:
+                capabilities['special'].append('SPI MISO (Master In Slave Out)')
+            elif pin_num == 13:
+                capabilities['special'].append('SPI SCK (Clock)')
+                capabilities['special'].append('Built-in LED')
+
+        # Analog pins
+        else:
+            analog_num = pin_num - 14
+            capabilities['analog'].append(f'Analog Input A{analog_num} (analogRead)')
+            capabilities['basic'].append('Can also be used as digital I/O')
+
+            # I2C
+            if pin_num == 18:  # A4
+                capabilities['special'].append('I2C SDA (Data)')
+            elif pin_num == 19:  # A5
+                capabilities['special'].append('I2C SCL (Clock)')
+
+        # Build HTML
+        html = f"""
+        <h3 style="color: #4EC9B0;">Basic Capabilities</h3>
+        <ul>
+        """
+
+        for cap in capabilities['basic']:
+            html += f"<li>{cap}</li>"
+
+        if capabilities['pwm']:
+            html += """
+            </ul>
+            <h3 style="color: #DCDCAA;">PWM (Pulse Width Modulation)</h3>
+            <ul>
+            """
+            for cap in capabilities['pwm']:
+                html += f"<li>{cap}</li>"
+
+        if capabilities['analog']:
+            html += """
+            </ul>
+            <h3 style="color: #CE9178;">Analog</h3>
+            <ul>
+            """
+            for cap in capabilities['analog']:
+                html += f"<li>{cap}</li>"
+
+        if capabilities['special']:
+            html += """
+            </ul>
+            <h3 style="color: #C586C0;">Special Functions</h3>
+            <ul>
+            """
+            for cap in capabilities['special']:
+                html += f"<li>{cap}</li>"
+
+        html += """
+        </ul>
+        <hr>
+        <h3 style="color: #569CD6;">Electrical Characteristics</h3>
+        <ul>
+            <li>Operating Voltage: 5V</li>
+            <li>Max Current per Pin: 40 mA</li>
+            <li>Recommended Current per Pin: 20 mA</li>
+            <li>Input Voltage Range: 0-5V</li>
+        """
+
+        if capabilities['pwm']:
+            html += "<li>PWM Frequency: ~490 Hz (pins 5,6: ~980 Hz)</li>"
+
+        if capabilities['analog']:
+            html += "<li>ADC Resolution: 10-bit (0-1023)</li>"
+            html += "<li>Analog Input Range: 0-5V</li>"
+
+        html += """
+        </ul>
+        """
+
+        return html
+
+
+class PinUsesDialog(QDialog):
+    """Dialog showing all uses of a pin in the code"""
+
+    def __init__(self, pin_info, occurrences, parent=None):
+        super().__init__(parent)
+        self.pin_info = pin_info
+        self.occurrences = occurrences
+        self.selected_position = None
+        self.setWindowTitle("Find Pin Uses")
+        self.setMinimumSize(500, 400)
+        self.setup_ui()
+
+    def setup_ui(self):
+        """Setup the dialog UI"""
+        layout = QVBoxLayout(self)
+
+        # Header
+        header = QLabel(f"Uses of {self.pin_info['display_name']} ({len(self.occurrences)} found)")
+        header.setStyleSheet("""
+            QLabel {
+                font-size: 14px;
+                font-weight: bold;
+                padding: 10px;
+                background-color: #2d2d2d;
+                color: #ffffff;
+            }
+        """)
+        layout.addWidget(header)
+
+        # List of occurrences
+        self.list_widget = QListWidget()
+        self.list_widget.setStyleSheet("""
+            QListWidget {
+                background-color: #1e1e1e;
+                color: #d4d4d4;
+                border: 1px solid #3e3e42;
+            }
+            QListWidget::item {
+                padding: 5px;
+                border-bottom: 1px solid #2d2d2d;
+            }
+            QListWidget::item:selected {
+                background-color: #094771;
+            }
+            QListWidget::item:hover {
+                background-color: #2a2d2e;
+            }
+        """)
+
+        # Get the full text to show context
+        if self.parent():
+            full_text = self.parent().toPlainText()
+            lines = full_text.split('\n')
+
+            for line_num, start, end, term in self.occurrences:
+                if 0 < line_num <= len(lines):
+                    line_text = lines[line_num - 1].strip()
+                    item = QListWidgetItem(f"Line {line_num}: {line_text}")
+                    item.setData(Qt.UserRole, start)  # Store position for jumping
+                    self.list_widget.addItem(item)
+
+        self.list_widget.itemDoubleClicked.connect(self.on_item_double_clicked)
+        layout.addWidget(self.list_widget)
+
+        # Buttons
+        button_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        button_box.accepted.connect(self.on_accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+
+    def on_item_double_clicked(self, item):
+        """Handle double-click on an item"""
+        self.selected_position = item.data(Qt.UserRole)
+        self.accept()
+
+    def on_accept(self):
+        """Handle OK button"""
+        current_item = self.list_widget.currentItem()
+        if current_item:
+            self.selected_position = current_item.data(Qt.UserRole)
+        self.accept()


### PR DESCRIPTION
Implemented intelligent right-click context menus that detect pin numbers in Arduino code and provide pin-specific actions:

Features:
- Pin detection: Recognizes numeric pins (0-13, A0-A7), special pins (LED_BUILTIN, SDA, SCL, etc.), and pin variables
- View in Pinout Diagram: Shows ASCII art Arduino Uno pinout with highlighted selected pin
- Show Pin Capabilities: Displays detailed capabilities including:
  * Digital I/O, PWM, Analog input capabilities
  * Special functions (Serial, SPI, I2C, interrupts)
  * Electrical characteristics
- Find Other Uses: Searches and lists all occurrences of the pin in code with ability to jump to each usage
- Generate pinMode(): Submenu with INPUT, OUTPUT, INPUT_PULLUP options that intelligently inserts pinMode() statements into setup() function

The context menu automatically detects when user right-clicks on:
- Raw pin numbers (0-19)
- Analog pin names (A0-A7)
- Special constants (LED_BUILTIN, SCL, SDA, SS, MOSI, MISO, SCK)
- Variables assigned to pins (e.g., int ledPin = 13)

Dialog classes included:
- PinDiagramDialog: Visual pinout reference
- PinCapabilitiesDialog: Comprehensive pin information
- PinUsesDialog: Code navigation for pin references