### PR TITLE
fix: Resolve context_panel AttributeError by fixing initialization order

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -134,6 +134,9 @@ class MainWindow(QMainWindow):
         self.create_dock_widgets()
         self.restore_state()
 
+        # Create initial editor (after dock widgets are created)
+        self.create_new_editor("sketch.ino")
+
         # Setup port auto-refresh timer
         self.setup_port_refresh()
 
@@ -154,9 +157,6 @@ class MainWindow(QMainWindow):
         self.editor_tabs.setMovable(True)
         self.editor_tabs.tabCloseRequested.connect(self.close_tab)
         self.editor_tabs.currentChanged.connect(self.on_tab_changed)
-
-        # Create initial editor
-        self.create_new_editor("sketch.ino")
 
         self.setCentralWidget(self.editor_tabs)
 


### PR DESCRIPTION
The create_new_editor method was being called during init_ui() before create_dock_widgets() had created the context_panel. This caused an AttributeError when trying to connect editor signals to the context panel.

Fixed by moving the initial editor creation to after dock widgets are created in the __init__ method.