### PR TITLE
fix: Add window flags to enable maximize button on Linux

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -151,6 +151,14 @@ class MainWindow(QMainWindow):
         self.setWindowTitle("Arduino IDE Modern")
         self.setGeometry(100, 100, 1600, 900)
 
+        # Explicitly set window flags to ensure maximize button is visible on Linux
+        self.setWindowFlags(
+            Qt.Window |
+            Qt.WindowMinimizeButtonHint |
+            Qt.WindowMaximizeButtonHint |
+            Qt.WindowCloseButtonHint
+        )
+
         # Central widget with editor tabs
         self.editor_tabs = QTabWidget()
         self.editor_tabs.setTabsClosable(True)


### PR DESCRIPTION
Explicitly set Qt.WindowMaximizeButtonHint to ensure the maximize button appears in the window title bar on Linux systems. Some Linux window managers don't show the maximize button by default without explicit window flags.

This fix adds the standard window control flags:
- Qt.Window
- Qt.WindowMinimizeButtonHint
- Qt.WindowMaximizeButtonHint
- Qt.WindowCloseButtonHint