### PR TITLE
feat: Make application start maximized

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -134,6 +134,9 @@ class MainWindow(QMainWindow):
         self.create_dock_widgets()
         self.restore_state()
 
+        # Start window maximized
+        self.showMaximized()
+
         # Create initial editor (after dock widgets are created)
         self.create_new_editor("sketch.ino")
 


### PR DESCRIPTION
- Add showMaximized() call after window initialization to ensure the IDE always starts in a maximized state
- Confirmed no minimum window size constraints exist on MainWindow (only on toolbar widgets for usability)
- Improves user experience by utilizing full screen space from startup