### PR TITLE
fix: Use showMaximized() for proper window maximization

### DIFF
--- a/arduino_ide/main.py
+++ b/arduino_ide/main.py
@@ -21,9 +21,9 @@ def main():
     app.setOrganizationName("Arduino IDE Modern")
     app.setApplicationVersion("0.1.0")
 
-    # Create and show main window
+    # Create and show main window maximized
     window = MainWindow()
-    window.show()
+    window.showMaximized()
 
     sys.exit(app.exec())
 

--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -139,9 +139,6 @@ class MainWindow(QMainWindow):
         if state:
             self.restoreState(state)
 
-        # Set window state to maximized
-        self.setWindowState(Qt.WindowMaximized)
-
         # Create initial editor (after dock widgets are created)
         self.create_new_editor("sketch.ino")
 
@@ -157,14 +154,6 @@ class MainWindow(QMainWindow):
     def init_ui(self):
         """Initialize the main UI"""
         self.setWindowTitle("Arduino IDE Modern")
-
-        # Explicitly set window flags to ensure maximize button is visible on Linux
-        self.setWindowFlags(
-            Qt.Window |
-            Qt.WindowMinimizeButtonHint |
-            Qt.WindowMaximizeButtonHint |
-            Qt.WindowCloseButtonHint
-        )
 
         # Central widget with editor tabs
         self.editor_tabs = QTabWidget()


### PR DESCRIPTION
- Remove custom window flags that were interfering with window manager
- Remove setWindowState() call from MainWindow constructor
- Change main.py to use showMaximized() instead of show()
- This properly maximizes the window and shows the maximize button with default window decorations