### PR TITLE
fix: Stop saving/restoring window geometry

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -908,16 +908,16 @@ void loop() {
             self.status_bar.update_board(board.name)
 
     def save_state(self):
-        """Save window state"""
-        self.settings.setValue("geometry", self.saveGeometry())
+        """Save window state (dock widgets only, not window geometry)"""
+        # Don't save geometry - we always want to start maximized
         self.settings.setValue("windowState", self.saveState())
 
     def restore_state(self):
-        """Restore window state"""
-        geometry = self.settings.value("geometry")
-        if geometry:
-            self.restoreGeometry(geometry)
+        """Restore window state (dock widgets only, not window geometry)"""
+        # Clear any old saved geometry to prevent issues
+        self.settings.remove("geometry")
 
+        # Only restore dock widget state
         state = self.settings.value("windowState")
         if state:
             self.restoreState(state)


### PR DESCRIPTION
The window geometry was being saved to QSettings on every close, causing the broken window size to persist and get worse each time.

Changes:
- Remove geometry save from save_state() - only save dock widget positions
- Clear any existing saved geometry on startup with settings.remove("geometry")
- Remove geometry restore from restore_state()
- Window will now always start maximized via showMaximized() without interference from saved geometry

This fixes the issue where the window was getting progressively worse on each restart.