### PR TITLE
Ensure main window shows maximize button

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -117,6 +117,13 @@ class MainWindow(QMainWindow):
         self.settings = QSettings()
         self.theme_manager = ThemeManager()
 
+        # Ensure minimize and maximize buttons are available on the title bar
+        self.setWindowFlags(
+            self.windowFlags()
+            | Qt.WindowMaximizeButtonHint
+            | Qt.WindowMinimizeButtonHint
+        )
+
         # Initialize package managers
         self.library_manager = LibraryManager()
         self.board_manager = BoardManager()


### PR DESCRIPTION
## Summary
- enable minimize and maximize title bar controls for the main window by setting window flags during initialization

## Testing
- python -m arduino_ide.main *(fails: ImportError: libGL.so.1 missing in container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69101019bd648331b54a1b65e8147efb)