### PR TITLE
Ensure main window opens maximized

### DIFF
--- a/arduino_ide/main.py
+++ b/arduino_ide/main.py
@@ -5,7 +5,7 @@ Main entry point for Arduino IDE Modern
 
 import sys
 from PySide6.QtWidgets import QApplication
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QTimer
 from arduino_ide.ui.main_window import MainWindow
 
 
@@ -23,7 +23,9 @@ def main():
 
     # Create and show main window maximized
     window = MainWindow()
+    window.setWindowState(window.windowState() | Qt.WindowMaximized)
     window.showMaximized()
+    QTimer.singleShot(0, window.showMaximized)
 
     sys.exit(app.exec())
 


### PR DESCRIPTION
## Summary
- maximize the main window explicitly when initializing the application
- reapply the maximize request once the Qt event loop starts to improve reliability

## Testing
- `python -m arduino_ide.main` *(fails: missing libGL.so.1 in container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910111093088331bc85f99dd27ef92a)