### PR TITLE
Adjust plotter dock sizing for smaller screens

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -8,7 +8,7 @@ from PySide6.QtWidgets import (
     QComboBox, QLabel
 )
 from PySide6.QtCore import Qt, QSettings, QTimer
-from PySide6.QtGui import QAction, QKeySequence, QIcon, QTextCursor
+from PySide6.QtGui import QAction, QKeySequence, QIcon, QTextCursor, QGuiApplication
 import serial.tools.list_ports
 from pathlib import Path
 
@@ -510,6 +510,29 @@ class MainWindow(QMainWindow):
 
         # Show console by default
         self.console_dock.raise_()
+
+        bottom_docks = [
+            self.console_dock,
+            self.serial_dock,
+            self.plotter_dock,
+            self.problems_dock,
+            self.output_dock,
+        ]
+
+        screen = QGuiApplication.primaryScreen()
+        if screen:
+            available_height = screen.availableGeometry().height()
+            max_bottom_height = max(int(available_height * 0.4), 240)
+            dock_min_height = max(100, int(max_bottom_height / len(bottom_docks)))
+        else:
+            max_bottom_height = 300
+            dock_min_height = 120
+
+        for dock in bottom_docks:
+            dock.setMinimumHeight(dock_min_height)
+
+        if screen:
+            self.resizeDocks([self.console_dock], [max_bottom_height], Qt.Vertical)
 
         # Connect Quick Actions Panel signals
         self.quick_actions_panel.upload_clicked.connect(self.upload_sketch)

--- a/arduino_ide/ui/plotter_panel.py
+++ b/arduino_ide/ui/plotter_panel.py
@@ -5,10 +5,11 @@ Displays real-time plots of serial data
 
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QPushButton,
-    QLabel, QComboBox, QCheckBox, QSpinBox, QFileDialog
+    QLabel, QComboBox, QCheckBox, QSpinBox, QFileDialog,
+    QSizePolicy
 )
 from PySide6.QtCore import Qt, Signal, QTimer
-from PySide6.QtGui import QPainter, QPen, QColor, QFont
+from PySide6.QtGui import QPainter, QPen, QColor, QFont, QGuiApplication
 import re
 import csv
 from datetime import datetime
@@ -30,7 +31,17 @@ class PlotWidget(QWidget):
             QColor(155, 89, 182),   # Purple
             QColor(230, 126, 34),   # Orange
         ]
-        self.setMinimumHeight(300)
+        screen = QGuiApplication.primaryScreen()
+        if screen:
+            available_height = screen.availableGeometry().height()
+            min_height = max(150, min(300, available_height // 3))
+        else:
+            min_height = 200
+
+        size_policy = QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Expanding)
+        size_policy.setVerticalStretch(1)
+        self.setSizePolicy(size_policy)
+        self.setMinimumHeight(min_height)
 
     def add_data_point(self, values, labels=None):
         """Add a data point (can be multiple series)"""


### PR DESCRIPTION
## Summary
- update the plotter widget to size itself based on the available screen height and allow vertical compression
- constrain the bottom dock widgets to screen-aware minimum heights and resize them to fit smaller displays

## Testing
- not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691011fc16bc8331b86b7230da4b9a9d)