### PR TITLE
Fix PySide6 import error by removing unused QWIDGETSIZE_MAX

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -7,7 +7,7 @@ from PySide6.QtWidgets import (
     QMenuBar, QMenu, QToolBar, QStatusBar, QTabWidget, QDockWidget,
     QComboBox, QLabel, QSizePolicy
 )
-from PySide6.QtCore import Qt, QSettings, QTimer, QWIDGETSIZE_MAX
+from PySide6.QtCore import Qt, QSettings, QTimer
 from PySide6.QtGui import QAction, QKeySequence, QIcon, QTextCursor, QGuiApplication
 import serial.tools.list_ports
 from pathlib import Path


### PR DESCRIPTION
Remove QWIDGETSIZE_MAX from PySide6.QtCore imports as this constant is not available in newer PySide6 versions and is not used anywhere in the codebase.

Fixes: ImportError: cannot import name 'QWIDGETSIZE_MAX' from 'PySide6.QtCore'