### PR TITLE
Fix corner policy: prevent Serial Monitor from extending under right …

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -190,6 +190,11 @@ class MainWindow(QMainWindow):
         )
         self.setDockNestingEnabled(True)
 
+        # Assign corners to right dock area so bottom docks (Serial Monitor, Console)
+        # don't extend under the right-side panels
+        self.setCorner(Qt.TopRightCorner, Qt.RightDockWidgetArea)
+        self.setCorner(Qt.BottomRightCorner, Qt.RightDockWidgetArea)
+
         # Central widget with editor tabs
         self.editor_tabs = QTabWidget()
         self.editor_tabs.setTabsClosable(True)


### PR DESCRIPTION
…panels

Critical fix: Assign top-right and bottom-right corners to RightDockWidgetArea. This ensures bottom docks (Serial Monitor, Console, etc.) only extend to the left edge of the right panel column, preventing overlap.

Changes:
- Added setCorner(Qt.TopRightCorner, Qt.RightDockWidgetArea)
- Added setCorner(Qt.BottomRightCorner, Qt.RightDockWidgetArea)

This completes the layout fix by ensuring proper dock area boundaries.