### PR TITLE
Refactor right panels to use QSplitter instead of Qt dock splitting

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -475,52 +475,33 @@ class MainWindow(QMainWindow):
         # Show Quick Actions by default
         self.quick_actions_dock.raise_()
 
-        # Board Panel (right)
-        self.board_dock = QDockWidget("Board Info", self)
-        self.board_dock.setObjectName("BoardInfoDock")
+        # Create right-side panel widgets
         self.board_panel = BoardPanel()
-        self.board_dock.setWidget(self.board_panel)
-        self.addDockWidget(Qt.RightDockWidgetArea, self.board_dock)
-
-        # Variable Watch (right, stacked vertically below board panel)
-        self.watch_dock = QDockWidget("Variables", self)
-        self.watch_dock.setObjectName("VariablesDock")
         self.variable_watch = VariableWatch()
-        self.watch_dock.setWidget(self.variable_watch)
-        self.addDockWidget(Qt.RightDockWidgetArea, self.watch_dock)
-        self.splitDockWidget(self.board_dock, self.watch_dock, Qt.Vertical)
-
-        # Status Display (right, stacked vertically below variables panel)
-        self.status_dock = QDockWidget("Real-time Status", self)
-        self.status_dock.setObjectName("RealTimeStatusDock")
         self.status_display = StatusDisplay()
-        self.status_dock.setWidget(self.status_display)
-        self.addDockWidget(Qt.RightDockWidgetArea, self.status_dock)
-        self.splitDockWidget(self.watch_dock, self.status_dock, Qt.Vertical)
-
-        # Context Panel (right, stacked vertically below status panel)
-        self.context_dock = QDockWidget("Context Help", self)
-        self.context_dock.setObjectName("ContextHelpDock")
         self.context_panel = ContextPanel()
-        self.context_dock.setWidget(self.context_panel)
-        self.addDockWidget(Qt.RightDockWidgetArea, self.context_dock)
-        self.splitDockWidget(self.status_dock, self.context_dock, Qt.Vertical)
 
-        # Set fixed width for right-side panels to ensure proper column layout
-        # This prevents the Serial Monitor from extending under the right panels
+        # Create a dedicated splitter for right docks
+        self.right_splitter = QSplitter(Qt.Vertical)
+        self.right_splitter.setObjectName("RightDockColumn")
+
+        # Add right panel widgets to the splitter
+        self.right_splitter.addWidget(self.board_panel)
+        self.right_splitter.addWidget(self.variable_watch)
+        self.right_splitter.addWidget(self.status_display)
+        self.right_splitter.addWidget(self.context_panel)
+
+        # Fix width of the whole splitter column
         right_panel_width = 320
-        right_docks = [
-            self.board_dock,
-            self.watch_dock,
-            self.status_dock,
-            self.context_dock
-        ]
-        for dock in right_docks:
-            dock.setMinimumWidth(right_panel_width)
-            dock.setMaximumWidth(right_panel_width)
+        self.right_splitter.setMinimumWidth(right_panel_width)
+        self.right_splitter.setMaximumWidth(right_panel_width)
 
-        # Resize the right-side panel column to the specified width
-        self.resizeDocks([self.board_dock], [right_panel_width], Qt.Horizontal)
+        # Wrap splitter in a dock widget and add to right area
+        self.right_dock = QDockWidget("Info Panels", self)
+        self.right_dock.setObjectName("RightDockColumn")
+        self.right_dock.setWidget(self.right_splitter)
+        self.right_dock.setFeatures(QDockWidget.NoDockWidgetFeatures)  # Prevent closing/floating
+        self.addDockWidget(Qt.RightDockWidgetArea, self.right_dock)
 
         # Console Panel (bottom)
         self.console_dock = QDockWidget("Console", self)
@@ -700,11 +681,10 @@ void loop() {
 
     def toggle_status_display(self):
         """Show/hide real-time status display"""
-        if self.status_dock.isVisible():
-            self.status_dock.hide()
+        if self.status_display.isVisible():
+            self.status_display.hide()
         else:
-            self.status_dock.show()
-            self.status_dock.raise_()
+            self.status_display.show()
 
     def toggle_plotter(self):
         """Show/hide serial plotter"""


### PR DESCRIPTION
Major improvement: Replace individual dock widgets with a single QSplitter-based column.

Changes:
- Created right_splitter (QSplitter with Qt.Vertical orientation)
- Added all right panel widgets (board_panel, variable_watch, status_display, context_panel) to the splitter
- Wrapped splitter in a single dock widget (right_dock) with NoDockWidgetFeatures
- Removed splitDockWidget() calls - splitter now handles vertical layout
- Fixed width (320px) applied to the splitter itself, not individual docks
- Updated toggle_status_display() to show/hide status_display widget instead of dock

Benefits:
- Splitter controls layout, not Qt's dock splitting logic
- Simpler architecture with one dock widget instead of four
- Users can resize panels within the splitter column
- Right column width remains fixed at 320px
- Serial Monitor no longer extends under right panels