### PR TITLE
Update corner policy: ensure bottom docks only attach to left side

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -190,9 +190,8 @@ class MainWindow(QMainWindow):
         )
         self.setDockNestingEnabled(True)
 
-        # Assign corners to right dock area so bottom docks (Serial Monitor, Console)
-        # don't extend under the right-side panels
-        self.setCorner(Qt.TopRightCorner, Qt.RightDockWidgetArea)
+        # Ensure bottom docks ONLY attach to the left side
+        self.setCorner(Qt.BottomLeftCorner, Qt.BottomDockWidgetArea)
         self.setCorner(Qt.BottomRightCorner, Qt.RightDockWidgetArea)
 
         # Central widget with editor tabs


### PR DESCRIPTION
Changes:
- Set BottomLeftCorner to BottomDockWidgetArea (bottom docks own left corner)
- Set BottomRightCorner to RightDockWidgetArea (right column owns right corner)
- Removed TopRightCorner assignment (not needed with QSplitter approach)

This is the critical setting that prevents the Serial Monitor from sliding under the right panel column. The bottom dock area now stops at the left edge of the right dock widget.