### PR TITLE
Implement about dialog using centralized metadata

### DIFF
--- a/arduino_ide/__init__.py
+++ b/arduino_ide/__init__.py
@@ -1,6 +1,8 @@
-"""
-Arduino IDE Modern - A modern Arduino development environment
-"""
+"""Arduino IDE Modern - A modern Arduino development environment"""
 
-__version__ = "0.1.0"
-__author__ = "Arduino IDE Modern Team"
+from .config import APP_AUTHORS, APP_VERSION
+
+__version__ = APP_VERSION
+__author__ = ", ".join(APP_AUTHORS)
+
+__all__ = ["__version__", "__author__"]

--- a/arduino_ide/config.py
+++ b/arduino_ide/config.py
@@ -1,0 +1,15 @@
+"""Centralized application metadata and configuration values."""
+
+APP_NAME = "Arduino IDE Modern"
+APP_ORGANIZATION = "Arduino IDE Modern"
+APP_VERSION = "0.1.0"
+APP_DESCRIPTION = "A modern Arduino development environment inspired by Arduino's ecosystem."
+APP_AUTHORS = ("Arduino IDE Modern Team",)
+APP_WEBSITE = "https://www.arduino.cc/"
+APP_SOURCE_REPO = "https://github.com/arduino"
+APP_ISSUE_TRACKER = "https://github.com/arduino/Arduino/issues"
+
+ABOUT_CREDITS = (
+    "Design & Development: Arduino IDE Modern Team",
+    "Built with PySide6",
+)

--- a/arduino_ide/main.py
+++ b/arduino_ide/main.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""
-Main entry point for Arduino IDE Modern
-"""
+"""Main entry point for Arduino IDE Modern"""
 
 import sys
 from PySide6.QtWidgets import QApplication
 from PySide6.QtCore import Qt, QTimer
+
+from arduino_ide.config import APP_NAME, APP_ORGANIZATION, APP_VERSION
 from arduino_ide.ui.main_window import MainWindow
 
 
@@ -17,9 +17,9 @@ def main():
     )
 
     app = QApplication(sys.argv)
-    app.setApplicationName("Arduino IDE Modern")
-    app.setOrganizationName("Arduino IDE Modern")
-    app.setApplicationVersion("0.1.0")
+    app.setApplicationName(APP_NAME)
+    app.setOrganizationName(APP_ORGANIZATION)
+    app.setApplicationVersion(APP_VERSION)
 
     # Create and show main window maximized
     window = MainWindow()

--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -906,8 +906,75 @@ void loop() {
 
     def show_about(self):
         """Show about dialog"""
-        # TODO: Implement about dialog
-        pass
+        from PySide6.QtCore import Qt, QUrl
+        from PySide6.QtGui import QDesktopServices
+        from PySide6.QtWidgets import QLabel, QMessageBox
+
+        from arduino_ide.config import (
+            ABOUT_CREDITS,
+            APP_AUTHORS,
+            APP_DESCRIPTION,
+            APP_NAME,
+            APP_SOURCE_REPO,
+            APP_VERSION,
+            APP_WEBSITE,
+        )
+
+        about_dialog = QMessageBox(self)
+        about_dialog.setIcon(QMessageBox.Information)
+        about_dialog.setWindowTitle(f"About {APP_NAME}")
+        about_dialog.setStandardButtons(QMessageBox.Close)
+        about_dialog.setDefaultButton(QMessageBox.Close)
+        about_dialog.setTextFormat(Qt.RichText)
+
+        credits_html = "".join(f"<li>{credit}</li>" for credit in ABOUT_CREDITS)
+        authors = ", ".join(APP_AUTHORS)
+        about_dialog.setText(
+            """
+            <div style="min-width: 320px;">
+                <h2 style="margin-bottom: 4px;">{name}</h2>
+                <p style="margin: 0 0 8px 0;"><strong>Version:</strong> {version}</p>
+                <p style="margin: 0 0 12px 0;">{description}</p>
+                <p style="margin: 0 0 8px 0;"><strong>Credits</strong></p>
+                <ul style="margin-top: 0; padding-left: 18px;">{credits}</ul>
+                <p style="margin: 12px 0 4px 0;">
+                    <strong>Project Links</strong><br>
+                    <a href="{website}">Official website</a><br>
+                    <a href="{repository}">Source repository</a>
+                </p>
+                <p style="margin: 12px 0 0 0;">Maintained by {authors}</p>
+            </div>
+            """.format(
+                name=APP_NAME,
+                version=APP_VERSION,
+                description=APP_DESCRIPTION,
+                credits=credits_html or "<li>No credits listed.</li>",
+                website=APP_WEBSITE,
+                repository=APP_SOURCE_REPO,
+                authors=authors,
+            )
+        )
+
+        about_dialog.setTextInteractionFlags(
+            Qt.TextBrowserInteraction
+            | Qt.LinksAccessibleByMouse
+            | Qt.TextSelectableByMouse
+        )
+
+        label = about_dialog.findChild(QLabel, "qt_msgbox_label")
+        if label is not None:
+            label.setOpenExternalLinks(True)
+            label.setTextInteractionFlags(
+                Qt.TextBrowserInteraction
+                | Qt.LinksAccessibleByMouse
+                | Qt.TextSelectableByMouse
+            )
+
+        def open_link(url: str) -> None:
+            QDesktopServices.openUrl(QUrl(url))
+
+        about_dialog.linkActivated.connect(open_link)
+        about_dialog.exec()
 
     def on_board_changed(self, board_name):
         """Handle board selection change"""

--- a/docs/manual_tests/about_dialog.md
+++ b/docs/manual_tests/about_dialog.md
@@ -1,0 +1,9 @@
+# About Dialog Manual Test
+
+Use this checklist to confirm that the About dialog displays the expected metadata.
+
+1. Launch the application with `python -m arduino_ide.main`.
+2. Open the **Help → About** menu item.
+3. Verify that the dialog shows the application name, version, and descriptive summary.
+4. Confirm that credit entries are listed.
+5. Click each link to ensure it opens in the system browser.


### PR DESCRIPTION
## Summary
- add a configuration module that centralizes application metadata
- wire application initialization and About dialog to use the shared metadata
- document a manual test for verifying the About dialog

## Testing
- Not run (UI change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910467e29288331880fb9aaaffd7852)