### PR TITLE
Implement cached package counting for offline mode

### DIFF
--- a/arduino_ide/services/background_updater.py
+++ b/arduino_ide/services/background_updater.py
@@ -8,6 +8,7 @@ Handles:
 - Scheduled updates
 """
 
+import json
 import time
 from pathlib import Path
 from typing import List, Dict, Optional
@@ -354,9 +355,33 @@ class OfflineMode:
         Returns:
             Number of cached packages
         """
-        # Count cached index entries
-        # TODO: Implement actual counting
-        return 0
+        cached_count = 0
+
+        index_files = [
+            (self.cache_dir / "library_index.json", "libraries"),
+            (self.cache_dir / "package_index.json", "packages"),
+        ]
+
+        for path, key in index_files:
+            if not path.exists():
+                continue
+
+            try:
+                with open(path, "r", encoding="utf-8") as fh:
+                    data = json.load(fh)
+
+                items = data.get(key, [])
+
+                if isinstance(items, list):
+                    cached_count += len(items)
+                elif isinstance(items, dict):
+                    cached_count += len(items)
+            except Exception:
+                # If a cache file is corrupt or unreadable, skip it without
+                # breaking offline mode functionality.
+                continue
+
+        return cached_count
 
     def get_offline_status_message(self) -> str:
         """

--- a/tests/test_offline_mode.py
+++ b/tests/test_offline_mode.py
@@ -1,0 +1,64 @@
+import json
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from arduino_ide.services import background_updater
+from arduino_ide.services.background_updater import OfflineMode
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_get_cached_packages_count(tmp_path, monkeypatch):
+    library_index = tmp_path / "library_index.json"
+    package_index = tmp_path / "package_index.json"
+
+    _write_json(
+        library_index,
+        {
+            "libraries": [
+                {"name": "LibA"},
+                {"name": "LibB"},
+                {"name": "LibC"},
+            ]
+        },
+    )
+
+    _write_json(
+        package_index,
+        {
+            "packages": [
+                {"name": "Pkg1"},
+                {"name": "Pkg2"},
+            ]
+        },
+    )
+
+    monkeypatch.setattr(background_updater.OfflineDetector, "is_online", lambda: False)
+
+    offline = OfflineMode(cache_dir=tmp_path)
+
+    assert offline.get_cached_packages_count() == 5
+
+
+def test_get_offline_status_message_reports_cached_count(tmp_path, monkeypatch):
+    library_index = tmp_path / "library_index.json"
+    package_index = tmp_path / "package_index.json"
+
+    _write_json(library_index, {"libraries": [{"name": "LibA"}]})
+    _write_json(package_index, {"packages": [{"name": "Pkg1"}, {"name": "Pkg2"}]})
+
+    monkeypatch.setattr(background_updater.OfflineDetector, "is_online", lambda: False)
+
+    offline = OfflineMode(cache_dir=tmp_path)
+
+    message = offline.get_offline_status_message()
+
+    assert "Offline Mode - Limited functionality" in message
+    assert "• 3 cached packages available" in message


### PR DESCRIPTION
## Summary
- count cached libraries and board packages by reading cache indices in OfflineMode
- add regression tests covering cached package counting and offline status message

## Testing
- pytest tests/test_offline_mode.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69104686f5e083318ea036b7fd35cb26)