### PR TITLE
Implement background updater aggregation and tests

### DIFF
--- a/arduino_ide/services/background_updater.py
+++ b/arduino_ide/services/background_updater.py
@@ -16,6 +16,9 @@ from threading import Thread, Event
 import requests
 from PySide6.QtCore import QObject, Signal
 
+from .library_manager import LibraryManager
+from .board_manager import BoardManager
+
 
 class OfflineDetector:
     """
@@ -113,6 +116,10 @@ class BackgroundUpdater(QObject):
 
         # Update callbacks
         self._update_callbacks: List[callable] = []
+
+        # Lazy loaded managers
+        self._library_manager: Optional[LibraryManager] = None
+        self._board_manager: Optional[BoardManager] = None
 
     def start(self):
         """Start background update checker"""
@@ -239,10 +246,81 @@ class BackgroundUpdater(QObject):
         Returns:
             List of update info dicts
         """
-        # This would integrate with LibraryManager and BoardManager
-        # For now, return empty list
-        # TODO: Integrate with actual managers
-        return []
+        updates: List[Dict] = []
+
+        if self.is_offline:
+            self.status_message.emit("Skipping update check while offline")
+            return updates
+
+        # Get library updates
+        library_manager = self._library_manager
+        if library_manager is None:
+            try:
+                library_manager = LibraryManager()
+                self._library_manager = library_manager
+            except Exception as exc:
+                self.status_message.emit(f"Unable to initialize LibraryManager: {exc}")
+                library_manager = None
+
+        if library_manager is not None:
+            try:
+                libraries_with_updates = []
+                if hasattr(library_manager, "library_index"):
+                    libraries_with_updates = library_manager.library_index.get_libraries_with_updates()
+
+                for library in libraries_with_updates:
+                    updates.append({
+                        "type": "library",
+                        "name": getattr(library, "name", ""),
+                        "current": getattr(library, "installed_version", "") or "",
+                        "latest": getattr(library, "latest_version", "") or "",
+                        "description": getattr(library, "description", "") or getattr(library, "sentence", ""),
+                        "metadata": {
+                            "author": getattr(library, "author", ""),
+                            "category": getattr(library, "category", ""),
+                        },
+                    })
+            except Exception as exc:
+                self.status_message.emit(f"Failed to check library updates: {exc}")
+
+        # Get board package updates
+        board_manager = self._board_manager
+        if board_manager is None:
+            try:
+                board_manager = BoardManager()
+                self._board_manager = board_manager
+            except Exception as exc:
+                self.status_message.emit(f"Unable to initialize BoardManager: {exc}")
+                board_manager = None
+
+        if board_manager is not None:
+            try:
+                packages_with_updates = []
+                if hasattr(board_manager, "board_index"):
+                    packages_with_updates = board_manager.board_index.get_packages_with_updates()
+
+                for package in packages_with_updates:
+                    category = getattr(package, "category", "")
+                    if hasattr(category, "value"):
+                        category_value = category.value
+                    else:
+                        category_value = str(category)
+
+                    updates.append({
+                        "type": "board",
+                        "name": getattr(package, "name", ""),
+                        "current": getattr(package, "installed_version", "") or "",
+                        "latest": getattr(package, "latest_version", "") or "",
+                        "description": getattr(package, "description", ""),
+                        "metadata": {
+                            "maintainer": getattr(package, "maintainer", ""),
+                            "category": category_value,
+                        },
+                    })
+            except Exception as exc:
+                self.status_message.emit(f"Failed to check board package updates: {exc}")
+
+        return updates
 
     def set_check_interval(self, hours: int):
         """

--- a/tests/test_background_updater.py
+++ b/tests/test_background_updater.py
@@ -1,0 +1,99 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from arduino_ide.models.board import BoardCategory
+from arduino_ide.services.background_updater import BackgroundUpdater
+
+
+class BackgroundUpdaterTests(unittest.TestCase):
+    def setUp(self):
+        self.updater = BackgroundUpdater()
+        self.messages = []
+        self.updater.status_message.connect(self.messages.append)
+
+    def test_find_updates_respects_offline_mode(self):
+        self.updater.is_offline = True
+
+        with patch("arduino_ide.services.background_updater.LibraryManager") as mock_lib_manager, \
+             patch("arduino_ide.services.background_updater.BoardManager") as mock_board_manager:
+            updates = self.updater._find_updates()
+
+        self.assertEqual(updates, [])
+        mock_lib_manager.assert_not_called()
+        mock_board_manager.assert_not_called()
+        self.assertTrue(any("offline" in message.lower() for message in self.messages))
+
+    def test_find_updates_aggregates_library_and_board_updates(self):
+        fake_library = SimpleNamespace(
+            name="Adafruit Sensor",
+            installed_version="1.0.0",
+            latest_version="1.2.0",
+            description="Sensor helpers",
+            sentence="",
+            author="Adafruit",
+            category="Sensors",
+        )
+
+        fake_package = SimpleNamespace(
+            name="Arduino AVR Boards",
+            installed_version="1.8.5",
+            latest_version="1.8.6",
+            description="Core boards",
+            maintainer="Arduino",
+            category=BoardCategory.OFFICIAL,
+        )
+
+        fake_library_manager = SimpleNamespace(
+            library_index=SimpleNamespace(
+                get_libraries_with_updates=lambda: [fake_library]
+            )
+        )
+        fake_board_manager = SimpleNamespace(
+            board_index=SimpleNamespace(
+                get_packages_with_updates=lambda: [fake_package]
+            )
+        )
+
+        with patch("arduino_ide.services.background_updater.LibraryManager", return_value=fake_library_manager) as lib_manager_cls, \
+             patch("arduino_ide.services.background_updater.BoardManager", return_value=fake_board_manager) as board_manager_cls:
+            updates = self.updater._find_updates()
+
+        self.assertEqual(len(updates), 2)
+
+        library_update = next(update for update in updates if update["type"] == "library")
+        self.assertEqual(library_update["name"], fake_library.name)
+        self.assertEqual(library_update["current"], fake_library.installed_version)
+        self.assertEqual(library_update["latest"], fake_library.latest_version)
+
+        board_update = next(update for update in updates if update["type"] == "board")
+        self.assertEqual(board_update["name"], fake_package.name)
+        self.assertEqual(board_update["current"], fake_package.installed_version)
+        self.assertEqual(board_update["latest"], fake_package.latest_version)
+
+        lib_manager_cls.assert_called_once()
+        board_manager_cls.assert_called_once()
+
+    def test_update_callbacks_receive_payload(self):
+        payload = [{
+            "type": "library",
+            "name": "Example",
+            "current": "1.0.0",
+            "latest": "1.1.0",
+        }]
+
+        callback_invocations = []
+        signal_payloads = []
+
+        self.updater.add_update_callback(lambda updates: callback_invocations.append(updates))
+        self.updater.updates_available.connect(lambda updates: signal_payloads.append(updates))
+
+        with patch.object(BackgroundUpdater, "_find_updates", return_value=payload):
+            self.updater._perform_update_check()
+
+        self.assertEqual(callback_invocations, [payload])
+        self.assertEqual(signal_payloads, [payload])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- integrate the background updater with the library and board managers to build update payloads
- cache manager instances, respect offline mode, and emit status messages when initialization or queries fail
- add unit tests covering offline handling, aggregation, and callback notification wiring

## Testing
- python -m unittest tests.test_background_updater

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910468632dc8331a208faa62e97f954)