### PR TITLE
Load library examples and add discovery tests

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -1128,11 +1128,48 @@ void loop() {
 
     def load_library_example(self, library_name, example_name):
         """Load a library example sketch"""
-        self.console_panel.append_output(f"Loading library example: {library_name}/{example_name}")
+        message = f"Loading library example: {library_name}/{example_name}"
+        self.console_panel.append_output(message)
         self.status_bar.set_status(f"Loading example: {library_name}/{example_name}")
-        # TODO: Implement library example loading
-        editor_container = self.create_new_editor(f"{example_name}.ino")
-        # Reset to Ready after a moment
+
+        example_path = self.library_manager.get_example_sketch_path(library_name, example_name)
+        if not example_path:
+            error_msg = (
+                f"Example '{example_name}' not found in library '{library_name}'."
+            )
+            self.console_panel.append_output(error_msg, color="#F48771")
+            self.status_bar.set_status(
+                f"Error loading {library_name}/{example_name}"
+            )
+            QMessageBox.warning(self, "Example Not Found", error_msg)
+            QTimer.singleShot(2000, lambda: self.status_bar.set_status("Ready"))
+            return
+
+        try:
+            with open(example_path, "r", encoding="utf-8") as sketch_file:
+                example_code = sketch_file.read()
+        except OSError as exc:
+            error_msg = (
+                f"Failed to read example '{library_name}/{example_name}': {exc}"
+            )
+            self.console_panel.append_output(error_msg, color="#F48771")
+            self.status_bar.set_status(
+                f"Error loading {library_name}/{example_name}"
+            )
+            QMessageBox.critical(self, "Error Loading Example", error_msg)
+            QTimer.singleShot(2000, lambda: self.status_bar.set_status("Ready"))
+            return
+
+        self.create_new_editor(
+            example_path.name,
+            file_path=str(example_path),
+            content=example_code,
+            mark_clean=True,
+        )
+
+        success_message = f"Loaded library example from {example_path}"
+        self.console_panel.append_output(success_message)
+        self.status_bar.set_status(f"Loaded: {library_name}/{example_name}")
         QTimer.singleShot(2000, lambda: self.status_bar.set_status("Ready"))
 
     def open_library_manager(self):

--- a/tests/test_library_example_discovery.py
+++ b/tests/test_library_example_discovery.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from arduino_ide.models import Library, LibraryIndex, LibraryType
+from arduino_ide.services.library_manager import LibraryManager
+
+
+def create_manager(tmp_path: Path) -> LibraryManager:
+    """Create a LibraryManager instance that uses a temporary workspace."""
+    manager = LibraryManager()
+    manager.base_dir = tmp_path
+    manager.libraries_dir = tmp_path / "libraries"
+    manager.cache_dir = tmp_path / "cache"
+    manager.index_file = manager.cache_dir / "library_index.json"
+    manager.installed_file = manager.cache_dir / "installed_libraries.json"
+    manager.libraries_dir.mkdir(parents=True, exist_ok=True)
+    manager.cache_dir.mkdir(parents=True, exist_ok=True)
+    manager.library_index = LibraryIndex()
+    manager.installed_libraries = {}
+    return manager
+
+
+def add_library(manager: LibraryManager, name: str, install_root: Path) -> Library:
+    library = Library(
+        name=name,
+        author="Tester",
+        description="Test library",
+        category="Testing",
+        lib_type=LibraryType.COMMUNITY,
+        installed_version="1.0.0",
+        install_path=str(install_root),
+    )
+    manager.library_index.libraries.append(library)
+    manager.installed_libraries[name] = "1.0.0"
+    return library
+
+
+def test_get_example_sketch_path_direct_match(tmp_path):
+    manager = create_manager(tmp_path)
+    servo_root = manager.libraries_dir / "Servo"
+    example_dir = servo_root / "examples" / "Sweep"
+    example_dir.mkdir(parents=True)
+    sketch_path = example_dir / "Sweep.ino"
+    sketch_path.write_text("// test sweep", encoding="utf-8")
+
+    add_library(manager, "Servo", servo_root)
+
+    resolved = manager.get_example_sketch_path("Servo", "Sweep")
+    assert resolved == sketch_path
+
+    resolved_with_extension = manager.get_example_sketch_path("Servo", "Sweep/Sweep.ino")
+    assert resolved_with_extension == sketch_path
+
+
+def test_get_example_sketch_path_nested_directory(tmp_path):
+    manager = create_manager(tmp_path)
+    wifi_root = manager.libraries_dir / "WiFi"
+    nested_dir = wifi_root / "examples" / "ESP32" / "WiFiScan"
+    nested_dir.mkdir(parents=True)
+    sketch_path = nested_dir / "WiFiScan.ino"
+    sketch_path.write_text("// wifi scan", encoding="utf-8")
+
+    add_library(manager, "WiFi", wifi_root)
+
+    resolved = manager.get_example_sketch_path("WiFi", "ESP32/WiFiScan")
+    assert resolved == sketch_path
+
+
+def test_get_example_sketch_path_missing_returns_none(tmp_path):
+    manager = create_manager(tmp_path)
+    add_library(manager, "Stepper", manager.libraries_dir / "Stepper")
+
+    assert manager.get_example_sketch_path("Stepper", "MissingExample") is None


### PR DESCRIPTION
## Summary
- add a LibraryManager helper to resolve installed library example sketches
- wire MainWindow.load_library_example to open sketches and report errors
- cover the discovery logic with pytest-based unit tests

## Testing
- pytest tests/test_library_example_discovery.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910466482bc833185f258b949676048)