### PR TITLE
Implement project explorer loading and tests

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -552,6 +552,7 @@ class MainWindow(QMainWindow):
         # Add widgets to left column layout (NOT as dock widgets)
         self.left_column_layout.addWidget(self.quick_actions_panel)
         self.left_column_layout.addWidget(self.project_explorer)
+        self.project_explorer.file_open_requested.connect(self.open_file_from_project_explorer)
 
         # --- RIGHT COLUMN (Normal widgets, NOT docks) ---
         # Create right-side panel widgets
@@ -755,36 +756,7 @@ void loop() {
         path = Path(file_path)
         self.settings.setValue("lastOpenDir", str(path.parent))
 
-        try:
-            contents = path.read_text(encoding="utf-8")
-        except Exception as exc:
-            QMessageBox.critical(
-                self,
-                "Open Sketch",
-                f"Failed to open {path.name}: {exc}"
-            )
-            self.status_bar.set_status("Ready")
-            return
-
-        existing_index, existing_container = self.find_editor_by_path(path)
-        if existing_container:
-            existing_container.set_file_path(path)
-            existing_container.set_content(contents, mark_clean=True)
-            self.editor_tabs.setCurrentIndex(existing_index)
-            self.update_status_bar_for_file(existing_container.filename)
-            self.update_tab_title(existing_index)
-        else:
-            editor_container = self.create_new_editor(
-                filename=path.name,
-                file_path=str(path),
-                content=contents,
-                mark_clean=True
-            )
-            editor_container.set_file_path(path)
-
-        self.add_recent_file(path)
-        self.status_bar.set_status(f"Opened {path.name}")
-        QTimer.singleShot(2000, lambda: self.status_bar.set_status("Ready"))
+        self._open_file_path(path)
 
     def save_file(self, checked=False, *, index=None, save_as=False):
         """Save current file"""
@@ -838,6 +810,42 @@ void loop() {
         self.update_tab_title(index)
         self.add_recent_file(path)
         self.update_status_bar_for_file(editor_container.filename)
+
+    def open_file_from_project_explorer(self, file_path: str):
+        """Open a file from the project explorer tree."""
+        self._open_file_path(Path(file_path))
+
+    def _open_file_path(self, path: Path):
+        try:
+            contents = path.read_text(encoding="utf-8")
+        except Exception as exc:
+            QMessageBox.critical(
+                self,
+                "Open Sketch",
+                f"Failed to open {path.name}: {exc}"
+            )
+            self.status_bar.set_status("Ready")
+            return
+
+        existing_index, existing_container = self.find_editor_by_path(path)
+        if existing_container:
+            existing_container.set_file_path(path)
+            existing_container.set_content(contents, mark_clean=True)
+            self.editor_tabs.setCurrentIndex(existing_index)
+            self.update_status_bar_for_file(existing_container.filename)
+            self.update_tab_title(existing_index)
+        else:
+            editor_container = self.create_new_editor(
+                filename=path.name,
+                file_path=str(path),
+                content=contents,
+                mark_clean=True
+            )
+            editor_container.set_file_path(path)
+
+        self.add_recent_file(path)
+        self.status_bar.set_status(f"Opened {path.name}")
+        QTimer.singleShot(2000, lambda: self.status_bar.set_status("Ready"))
 
         self.status_bar.set_status(f"Saved {path.name}")
         QTimer.singleShot(2000, lambda: self.status_bar.set_status("Ready"))

--- a/arduino_ide/ui/project_explorer.py
+++ b/arduino_ide/ui/project_explorer.py
@@ -1,20 +1,34 @@
-"""
-Project explorer for file navigation
-"""
+"""Project explorer for file navigation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
 
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QTreeView, QPushButton, QHBoxLayout,
-    QFileSystemModel, QMenu
 )
-from PySide6.QtCore import Qt, QDir
+from PySide6.QtCore import Qt, Signal, QModelIndex
 from PySide6.QtGui import QStandardItemModel, QStandardItem
+
+
+PATH_ROLE = Qt.UserRole + 1
+IS_DIR_ROLE = Qt.UserRole + 2
+RELATIVE_PATH_ROLE = Qt.UserRole + 3
 
 
 class ProjectExplorer(QWidget):
     """Project file explorer"""
 
+    file_open_requested = Signal(str)
+
+    IGNORED_DIRECTORIES = {".git", "__pycache__", ".idea", ".vscode", "node_modules"}
+    IGNORED_FILES = {".DS_Store", "Thumbs.db"}
+    IGNORED_SUFFIXES = {".pyc", ".pyo", ".swp", ".tmp"}
+
     def __init__(self, parent=None):
         super().__init__(parent)
+        self._project_root: Path | None = None
         self.init_ui()
 
     def init_ui(self):
@@ -24,20 +38,21 @@ class ProjectExplorer(QWidget):
         # Toolbar
         toolbar = QHBoxLayout()
 
-        new_file_btn = QPushButton("+")
-        new_file_btn.setToolTip("New File")
-        new_file_btn.setMaximumWidth(30)
-        toolbar.addWidget(new_file_btn)
+        self.new_file_btn = QPushButton("+")
+        self.new_file_btn.setToolTip("New File")
+        self.new_file_btn.setMaximumWidth(30)
+        toolbar.addWidget(self.new_file_btn)
 
-        new_folder_btn = QPushButton("📁+")
-        new_folder_btn.setToolTip("New Folder")
-        new_folder_btn.setMaximumWidth(30)
-        toolbar.addWidget(new_folder_btn)
+        self.new_folder_btn = QPushButton("📁+")
+        self.new_folder_btn.setToolTip("New Folder")
+        self.new_folder_btn.setMaximumWidth(30)
+        toolbar.addWidget(self.new_folder_btn)
 
-        refresh_btn = QPushButton("🔄")
-        refresh_btn.setToolTip("Refresh")
-        refresh_btn.setMaximumWidth(30)
-        toolbar.addWidget(refresh_btn)
+        self.refresh_btn = QPushButton("🔄")
+        self.refresh_btn.setToolTip("Refresh")
+        self.refresh_btn.setMaximumWidth(30)
+        self.refresh_btn.clicked.connect(self.refresh)
+        toolbar.addWidget(self.refresh_btn)
 
         toolbar.addStretch()
 
@@ -49,29 +64,116 @@ class ProjectExplorer(QWidget):
 
         # Use a simple model for now
         self.model = QStandardItemModel()
-
-        root_item = QStandardItem("📁 My Project")
-
-        # Add example files
-        main_file = QStandardItem("📄 sketch.ino")
-        root_item.appendRow(main_file)
-
-        lib_folder = QStandardItem("📁 libraries")
-        lib_file = QStandardItem("📄 mylib.h")
-        lib_folder.appendRow(lib_file)
-        root_item.appendRow(lib_folder)
-
-        readme = QStandardItem("📄 README.md")
-        root_item.appendRow(readme)
-
-        self.model.appendRow(root_item)
-
+        self.model.setHorizontalHeaderLabels(["Project Files"])
         self.tree_view.setModel(self.model)
+        self.tree_view.clicked.connect(self.on_item_clicked)
         self.tree_view.expandAll()
 
         layout.addWidget(self.tree_view)
 
     def load_project(self, project_path):
         """Load project from path"""
-        # TODO: Implement project loading
-        pass
+        root = Path(project_path).expanduser().resolve()
+
+        if not root.exists():
+            return
+
+        self._project_root = root
+        self._rebuild_model()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _rebuild_model(self):
+        if self._project_root is None:
+            return
+
+        self.model.clear()
+        self.model.setHorizontalHeaderLabels(["Project Files"])
+
+        root_item = self._create_item(self._project_root, is_root=True)
+        self.model.appendRow(root_item)
+
+        self._populate_children(root_item, self._project_root)
+
+        # Expand the top level for better visibility
+        self.tree_view.expand(self.model.indexFromItem(root_item))
+        self.tree_view.expandAll()
+
+    def _populate_children(self, parent_item: QStandardItem, directory: Path):
+        for entry in self._iter_directory(directory):
+            if entry.is_dir():
+                item = self._create_item(entry)
+                parent_item.appendRow(item)
+                self._populate_children(item, entry)
+            else:
+                parent_item.appendRow(self._create_item(entry))
+
+    def _create_item(self, path: Path, *, is_root: bool = False) -> QStandardItem:
+        prefix = "📁" if path.is_dir() else "📄"
+        label = path.name if not is_root else path.name or str(path)
+        item = QStandardItem(f"{prefix} {label}")
+        item.setEditable(False)
+
+        item.setData(str(path), PATH_ROLE)
+        item.setData(path.is_dir(), IS_DIR_ROLE)
+        if self._project_root and path != self._project_root:
+            try:
+                relative = path.relative_to(self._project_root)
+            except ValueError:
+                relative = path.name
+            item.setData(str(relative), RELATIVE_PATH_ROLE)
+        else:
+            item.setData(".", RELATIVE_PATH_ROLE)
+
+        tooltip_lines = [str(path)]
+        if path.is_dir():
+            tooltip_lines.append("Directory")
+        else:
+            tooltip_lines.append("File")
+        item.setToolTip("\n".join(tooltip_lines))
+        return item
+
+    def _iter_directory(self, directory: Path) -> Iterable[Path]:
+        try:
+            entries = list(directory.iterdir())
+        except (PermissionError, OSError):
+            return []
+
+        def sort_key(path: Path):
+            return (path.is_file(), path.name.lower())
+
+        for entry in sorted(entries, key=sort_key):
+            if self._should_ignore(entry):
+                continue
+            yield entry
+
+    def _should_ignore(self, path: Path) -> bool:
+        name = path.name
+        if path.is_dir():
+            return name in self.IGNORED_DIRECTORIES
+        if name in self.IGNORED_FILES:
+            return True
+        return any(name.endswith(suffix) for suffix in self.IGNORED_SUFFIXES)
+
+    # ------------------------------------------------------------------
+    # Slots / actions
+    # ------------------------------------------------------------------
+    def refresh(self):
+        """Refresh the current project tree"""
+        self._rebuild_model()
+
+    def on_item_clicked(self, index: QModelIndex):
+        item = self.model.itemFromIndex(index)
+        if not item:
+            return
+
+        is_dir = bool(item.data(IS_DIR_ROLE))
+        path = item.data(PATH_ROLE)
+
+        if is_dir or not path:
+            return
+
+        file_path = Path(path)
+        if file_path.is_file():
+            self.file_open_requested.emit(str(file_path))

--- a/test_project_explorer.py
+++ b/test_project_explorer.py
@@ -1,0 +1,94 @@
+import pytest
+
+pytest.importorskip(
+    "PySide6.QtWidgets",
+    reason="PySide6 (and libGL) not available in the test environment",
+)
+
+from PySide6.QtWidgets import QApplication
+
+from arduino_ide.ui.project_explorer import (
+    ProjectExplorer,
+    PATH_ROLE,
+    IS_DIR_ROLE,
+)
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+def collect_child_items(item):
+    return [item.child(row) for row in range(item.rowCount())]
+
+
+def test_load_project_populates_tree_with_metadata(tmp_path, qt_app):
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    main_file = src_dir / "sketch.ino"
+    main_file.write_text("void setup(){}\n")
+
+    readme = tmp_path / "README.md"
+    readme.write_text("# Example\n")
+
+    ignored_dir = tmp_path / ".git"
+    ignored_dir.mkdir()
+    (ignored_dir / "config").write_text("[core]\n")
+
+    ignored_file = tmp_path / "Thumbs.db"
+    ignored_file.write_text("binary")
+
+    explorer = ProjectExplorer()
+    explorer.load_project(tmp_path)
+
+    root_item = explorer.model.item(0, 0)
+    assert root_item is not None
+    assert root_item.data(PATH_ROLE) == str(tmp_path.resolve())
+
+    children = collect_child_items(root_item)
+    child_paths = {child.data(PATH_ROLE) for child in children}
+
+    assert str(src_dir.resolve()) in child_paths
+    assert str(readme.resolve()) in child_paths
+    assert str(ignored_dir.resolve()) not in child_paths
+    assert str(ignored_file.resolve()) not in child_paths
+
+    src_item = next(child for child in children if child.data(PATH_ROLE) == str(src_dir.resolve()))
+    assert bool(src_item.data(IS_DIR_ROLE)) is True
+
+    src_children = collect_child_items(src_item)
+    assert any(child.data(PATH_ROLE) == str(main_file.resolve()) for child in src_children)
+
+
+def test_refresh_updates_tree_and_emits_signal(tmp_path, qt_app):
+    initial_file = tmp_path / "main.ino"
+    initial_file.write_text("void loop(){}\n")
+
+    explorer = ProjectExplorer()
+    explorer.load_project(tmp_path)
+
+    received = []
+    explorer.file_open_requested.connect(received.append)
+
+    root_item = explorer.model.item(0, 0)
+    file_item = next(
+        child for child in collect_child_items(root_item)
+        if not child.data(IS_DIR_ROLE)
+    )
+    explorer.on_item_clicked(explorer.model.indexFromItem(file_item))
+    assert received == [file_item.data(PATH_ROLE)]
+
+    new_file = tmp_path / "util.cpp"
+    new_file.write_text("int util() { return 0; }\n")
+
+    explorer.refresh()
+
+    root_item = explorer.model.item(0, 0)
+    paths_after_refresh = {
+        child.data(PATH_ROLE) for child in collect_child_items(root_item)
+    }
+    assert str(new_file.resolve()) in paths_after_refresh


### PR DESCRIPTION
## Summary
- build the project explorer tree from the filesystem with metadata, refresh handling, and ignored entries
- emit file-open signals from the explorer and hook the main window to open selected files
- add tests that cover nested folders, ignored files, and refresh behavior

## Testing
- pytest test_project_explorer.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910468256d08331b40493cb5ba9d8da)