### PR TITLE
Fix console stream newline detection

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -871,9 +871,7 @@ void loop() {
         if not chunk:
             return
         lines = chunk.splitlines()
-        if chunk.endswith("
-") or chunk.endswith("
-"):
+        if chunk.endswith(("\n", "\r")):
             lines.append("")
         for line in lines:
             self.console_panel.append_output(line, color=color)


### PR DESCRIPTION
## Summary
- replace the malformed newline check in the console stream handler with a tuple-based suffix test to avoid syntax errors

## Testing
- python run.py *(fails: ImportError: libGL.so.1: cannot open shared object file)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69104aa7fe9883319aa20a61c94424af)