### PR TITLE
Add missing Arduino core functions and constants

### DIFF
--- a/arduino_ide/cores/arduino/Arduino.cpp
+++ b/arduino_ide/cores/arduino/Arduino.cpp
@@ -127,3 +127,30 @@ void detachInterrupt(uint8_t interruptNum) {
     // Stub implementation
     (void)interruptNum;
 }
+
+// Random number functions
+void randomSeed(unsigned long seed) {
+    if (seed != 0) {
+        srand(seed);
+    }
+}
+
+long random(long howbig) {
+    if (howbig == 0) {
+        return 0;
+    }
+    return rand() % howbig;
+}
+
+long random(long howsmall, long howbig) {
+    if (howsmall >= howbig) {
+        return howsmall;
+    }
+    long diff = howbig - howsmall;
+    return random(diff) + howsmall;
+}
+
+// Math utility functions
+long map(long x, long in_min, long in_max, long out_min, long out_max) {
+    return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
+}

--- a/arduino_ide/cores/arduino/Arduino.h
+++ b/arduino_ide/cores/arduino/Arduino.h
@@ -29,6 +29,14 @@ extern "C"{
 // Pin Definitions for Arduino Uno
 #define LED_BUILTIN 13
 
+// Analog pin definitions (A0-A5 for Arduino Uno)
+#define A0 14
+#define A1 15
+#define A2 16
+#define A3 17
+#define A4 18
+#define A5 19
+
 // Boolean
 #define true 0x1
 #define false 0x0
@@ -74,6 +82,18 @@ uint8_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder);
 
 void attachInterrupt(uint8_t interruptNum, void (*userFunc)(void), int mode);
 void detachInterrupt(uint8_t interruptNum);
+
+// Random number functions
+void randomSeed(unsigned long seed);
+long random(long howbig);
+long random(long howsmall, long howbig);
+
+// Math utility functions
+long map(long x, long in_min, long in_max, long out_min, long out_max);
+#define constrain(amt,low,high) ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
+#define min(a,b) ((a)<(b)?(a):(b))
+#define max(a,b) ((a)>(b)?(a):(b))
+#define abs(x) ((x)>0?(x):-(x))
 
 void setup(void);
 void loop(void);


### PR DESCRIPTION
This commit fixes compilation errors for sketches using random(), randomSeed(), and analog pin constants (A0-A5).

Changes:
- Added analog pin definitions (A0-A5) for Arduino Uno
- Implemented random() and randomSeed() functions
- Added math utility functions (map, constrain, min, max, abs)

The Arduino core was too minimal and was causing sketches to fail compilation because they were finding the standard C library random() instead of the Arduino version, and analog pin constants were not defined.