### PR TITLE
Fix compilation: include main.cpp and assembly files

### DIFF
--- a/arduino-cli
+++ b/arduino-cli
@@ -475,14 +475,27 @@ class ArduinoCLI:
             core_obj_file = build_dir / f"{core_source.stem}.o"
             core_obj_files.append(core_obj_file)
 
+            # Determine if this is an assembly file
+            is_assembly = core_source.suffix == '.S'
+
             core_compile_flags = [
                 str(toolchain.get_avr_gcc_path()),
                 '-c',
                 '-g',
-                '-Os',
-                '-w',
-                f'-mmcu={mcu}',
             ]
+
+            # Assembly files need different flags
+            if is_assembly:
+                core_compile_flags.extend([
+                    '-x', 'assembler-with-cpp',  # Treat as assembly with C preprocessor
+                ])
+            else:
+                core_compile_flags.extend([
+                    '-Os',  # Optimize for size (not for assembly)
+                ])
+
+            core_compile_flags.append('-w')  # Suppress warnings
+            core_compile_flags.append(f'-mmcu={mcu}')
 
             # Add same -B flags
             if specs_dir.exists():

--- a/arduino_ide/services/core_manager.py
+++ b/arduino_ide/services/core_manager.py
@@ -213,7 +213,7 @@ class CoreManager:
         return self.download_core()
 
     def get_core_sources(self) -> list[Path]:
-        """Get list of all core source files (.c, .cpp) that need to be compiled
+        """Get list of all core source files (.c, .cpp, .S) that need to be compiled
 
         Returns:
             List of source file paths
@@ -224,12 +224,10 @@ class CoreManager:
         core_path = self.get_core_path()
         sources = []
 
-        # Add all .c and .cpp files except main.cpp
-        for ext in ['*.c', '*.cpp']:
+        # Add all .c, .cpp, and .S (assembly) files INCLUDING main.cpp
+        for ext in ['*.c', '*.cpp', '*.S']:
             for source in core_path.glob(ext):
-                # Skip main.cpp as it conflicts with the sketch's main
-                if source.name != 'main.cpp':
-                    sources.append(source)
+                sources.append(source)
 
         return sources
 


### PR DESCRIPTION
Fixed two linking errors:
1. "undefined reference to main" - Now includes main.cpp from Arduino core
2. "undefined reference to countPulseASM" - Now compiles .S assembly files

Changes:
- CoreManager.get_core_sources() now includes all .c, .cpp, AND .S files
- Removed exclusion of main.cpp (it's needed for the main entry point)
- Added assembly file handling with -x assembler-with-cpp flag
- Assembly files compiled without -Os optimization flag

The official Arduino core's main.cpp provides the entry point that calls setup() once and loop() repeatedly.