### PR TITLE
Fix object file name collision for duplicate source stems

### DIFF
--- a/arduino-cli
+++ b/arduino-cli
@@ -472,7 +472,9 @@ class ArduinoCLI:
         print(f"Compiling {len(core_sources)} core source files...", flush=True)
 
         for core_source in core_sources:
-            core_obj_file = build_dir / f"{core_source.stem}.o"
+            # Use full filename (with extension) to avoid collisions between .c and .S files with same name
+            # e.g., wiring_pulse.c → wiring_pulse.c.o, wiring_pulse.S → wiring_pulse.S.o
+            core_obj_file = build_dir / f"{core_source.name}.o"
             core_obj_files.append(core_obj_file)
 
             # Determine if this is an assembly file


### PR DESCRIPTION
When both wiring_pulse.c and wiring_pulse.S exist, they were both creating wiring_pulse.o, causing "multiple definition" linking errors.

Changed object file naming from:
  {stem}.o  (e.g., wiring_pulse.o)
To:
  {name}.o  (e.g., wiring_pulse.c.o, wiring_pulse.S.o)

This ensures each source file gets a unique object file name.