### PR TITLE
Enable section garbage collection for AVR builds

### DIFF
--- a/arduino-cli
+++ b/arduino-cli
@@ -405,6 +405,8 @@ class ArduinoCLI:
             '-c',  # Compile only, don't link
             '-g',  # Debug info
             '-Os',  # Optimize for size
+            '-ffunction-sections',  # Place each function in its own section
+            '-fdata-sections',  # Place each data item in its own section
             '-w',  # Suppress warnings
             f'-mmcu={mcu}',
         ]
@@ -494,6 +496,8 @@ class ArduinoCLI:
             else:
                 core_compile_flags.extend([
                     '-Os',  # Optimize for size (not for assembly)
+                    '-ffunction-sections',
+                    '-fdata-sections',
                 ])
 
             core_compile_flags.append('-w')  # Suppress warnings
@@ -536,6 +540,7 @@ class ArduinoCLI:
             str(toolchain.get_avr_gcc_path()),
             '-Os',
             f'-mmcu={mcu}',
+            '-Wl,--gc-sections',
         ]
 
         # Add same -B flags for linking


### PR DESCRIPTION
## Summary
- add `-ffunction-sections` and `-fdata-sections` to sketch and core compilation flags
- pass `-Wl,--gc-sections` to the AVR link step so unused sections can be discarded

## Testing
- `./arduino-cli compile -b arduino:avr:uno /tmp/basic_serial_sketch` *(fails: AVR toolchain download blocked in execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69129f2851788331b0ca72215d569b26)