### PR TITLE
Create core.a archive library to match official Arduino IDE linking

### DIFF
--- a/arduino-cli
+++ b/arduino-cli
@@ -564,6 +564,29 @@ class ArduinoCLI:
                 print(f"✗ Core compilation error for {core_source.name}: {exc}", file=sys.stderr)
                 return 1
 
+        # Create static library archive from core object files
+        # This is critical - the official Arduino IDE creates core.a and links against it
+        # Linking against an archive (.a) only includes needed object files
+        # Linking against individual .o files includes ALL of them (causing bloat)
+        core_archive = build_dir / 'core.a'
+
+        # Use avr-ar to create the archive
+        ar_cmd = [
+            str(toolchain.get_avr_ar_path()),
+            'rcs',  # r=insert/replace, c=create, s=index
+            str(core_archive)
+        ]
+        ar_cmd.extend([str(obj) for obj in core_obj_files])
+
+        try:
+            result = subprocess.run(ar_cmd, capture_output=True, text=True, timeout=30, env=env)
+            if result.returncode != 0:
+                print(f"✗ Archive creation failed:\n{result.stderr}", file=sys.stderr)
+                return result.returncode
+        except Exception as exc:
+            print(f"✗ Archive creation error: {exc}", file=sys.stderr)
+            return 1
+
         # Link - matches official Arduino AVR core platform.txt compiler.c.elf.flags
         link_flags = [
             str(toolchain.get_avr_gcc_path()),
@@ -598,10 +621,12 @@ class ArduinoCLI:
             str(sketch_obj_file),
         ])
 
-        # Add all core object files
-        link_flags.extend([str(obj) for obj in core_obj_files])
+        # Add core archive library
+        # The order matters: sketch objects first, then core archive, then system libraries
+        # The linker will only extract needed object files from the archive
+        link_flags.append(str(core_archive))
 
-        # Add math library
+        # Add math library (-lm must come after object files/archives)
         link_flags.append('-lm')
 
         try:

--- a/arduino_ide/services/toolchain_manager.py
+++ b/arduino_ide/services/toolchain_manager.py
@@ -100,6 +100,12 @@ class ToolchainManager:
             return self.avr_dir / 'bin' / 'avr-objcopy.exe'
         return self.avr_dir / 'bin' / 'avr-objcopy'
 
+    def get_avr_ar_path(self) -> Path:
+        """Get path to avr-ar (archiver) executable"""
+        if platform.system() == 'Windows':
+            return self.avr_dir / 'bin' / 'avr-ar.exe'
+        return self.avr_dir / 'bin' / 'avr-ar'
+
     def download_toolchain(self, progress_callback=None) -> bool:
         """Download and install AVR toolchain
 


### PR DESCRIPTION
This is a critical fix for binary bloat. The official Arduino IDE creates a static archive library (core.a) from compiled core files, then links against that archive. Linking against an archive allows the linker to selectively extract only the object files that are actually needed.

Previous behavior:
- Linked all core .o files directly
- Linker included ALL core files (even unused ones)
- Result: 2454 bytes for basic sketch (70% larger than official IDE)

New behavior:
- Compile core files to .o files
- Use avr-ar to create core.a archive with 'rcs' flags
- Link sketch against core.a archive
- Linker only extracts needed object files from archive
- Expected result: ~1438 bytes (matching official IDE)

Changes:
- Add avr-ar archiving step after core compilation
- Replace direct .o linking with core.a archive linking
- Add get_avr_ar_path() method to ToolchainManager
- Maintain correct link order: sketch.o, core.a, then -lm

This matches the official Arduino AVR core recipe.c.combine.pattern which uses {archive_file} instead of linking individual object files.