### PR TITLE
Use avr-gcc-ar instead of avr-ar for LTO compatibility

### DIFF
--- a/arduino_ide/services/toolchain_manager.py
+++ b/arduino_ide/services/toolchain_manager.py
@@ -101,10 +101,14 @@ class ToolchainManager:
         return self.avr_dir / 'bin' / 'avr-objcopy'
 
     def get_avr_ar_path(self) -> Path:
-        """Get path to avr-ar (archiver) executable"""
+        """Get path to avr-gcc-ar (archiver) executable
+
+        Note: We use avr-gcc-ar instead of avr-ar because it's LTO-aware
+        and properly handles LTO object files created with -flto
+        """
         if platform.system() == 'Windows':
-            return self.avr_dir / 'bin' / 'avr-ar.exe'
-        return self.avr_dir / 'bin' / 'avr-ar'
+            return self.avr_dir / 'bin' / 'avr-gcc-ar.exe'
+        return self.avr_dir / 'bin' / 'avr-gcc-ar'
 
     def download_toolchain(self, progress_callback=None) -> bool:
         """Download and install AVR toolchain


### PR DESCRIPTION
This fixes the "undefined reference to main" linking error that occurred when using LTO with static archives.

Root cause:
- When compiling with -flto, object files contain LTO bytecode
- Standard avr-ar doesn't understand LTO object files
- The linker couldn't extract main.o from core.a, causing link failures

Solution:
- Use avr-gcc-ar (GCC-wrapped archiver) instead of avr-ar
- avr-gcc-ar is LTO-aware and properly handles LTO object files
- This matches the official Arduino IDE build process

The official Arduino IDE uses:
  avr-gcc-ar rcs core.a *.o

Not:
  avr-ar rcs core.a *.o

This is a critical fix for LTO-enabled builds with static libraries.