### PR TITLE
Wire real-time memory monitor to use actual compilation results

### DIFF
--- a/arduino_ide/ui/status_display.py
+++ b/arduino_ide/ui/status_display.py
@@ -617,6 +617,23 @@ class StatusDisplay(QWidget):
         self.flash_bar.update_usage(flash_used, self.board_specs["flash_total"])
         self.ram_bar.update_usage(ram_used, self.board_specs["ram_total"])
 
+    def update_from_compilation(self, flash_used, flash_max, ram_used, ram_max):
+        """Update memory usage from actual compilation results
+
+        Args:
+            flash_used: Actual flash/program storage used in bytes
+            flash_max: Maximum flash available in bytes
+            ram_used: Actual RAM/dynamic memory used in bytes
+            ram_max: Maximum RAM available in bytes
+        """
+        # Update board specs with actual values from compilation
+        self.board_specs["flash_total"] = flash_max
+        self.board_specs["ram_total"] = ram_max
+
+        # Update displays with actual compilation results
+        self.flash_bar.update_usage(flash_used, flash_max)
+        self.ram_bar.update_usage(ram_used, ram_max)
+
     def update_board(self, board_name):
         """Update board specifications"""
         # Board specifications database


### PR DESCRIPTION
This connects the memory usage monitor to display actual compilation results instead of just estimates, and wires the upload button to verify (compile) before uploading.

Changes to StatusDisplay:
- Add update_from_compilation() method to accept actual memory usage data
- Accepts flash_used, flash_max, ram_used, ram_max from compilation
- Updates both the display and board specs with actual values

Changes to MainWindow:
- Add _compilation_output buffer to capture compilation output
- Add _upload_after_compile flag to trigger upload after successful compile
- Add _parse_and_update_memory_usage() to extract memory from CLI output
  - Parses "Sketch uses X bytes... Maximum is Y bytes" for flash
  - Parses "Global variables use X bytes... Maximum is Y bytes" for RAM
  - Updates status display with actual compilation results
- Modify upload_sketch() to compile first, then upload:
  - Step 1: Compile/verify the sketch
  - Step 2: Upload to board (triggered after successful compilation)
- Add _do_upload() helper to perform actual upload after compilation
- Enhanced CLI output handling to store compilation data
- Enhanced CLI finished handler to parse memory and trigger upload

User Experience:
- Clicking "Upload" now:
  1. Saves sketch if needed
  2. Compiles/verifies sketch
  3. Shows actual memory usage in real-time monitor
  4. Uploads to board if compilation succeeds
- Memory monitor shows:
  - Estimates while typing (real-time analysis)
  - Actual values after compilation (100% accurate)
- Console shows clear "Step 1" and "Step 2" messages

This matches the official Arduino IDE behavior where upload always verifies first to ensure the code compiles before attempting upload.