### PR TITLE
Add automatic function prototype generation to arduino-cli

### DIFF
--- a/arduino-cli
+++ b/arduino-cli
@@ -311,6 +311,67 @@ class ArduinoCLI:
         # Default fallback (assumes Uno-like board with 2KB bootloader)
         return 30720 if is_flash else 2048
 
+    def _generate_function_prototypes(self, source: str) -> List[str]:
+        """
+        Generate forward declarations for all user-defined functions in the sketch.
+
+        This mimics the behavior of the official Arduino IDE which automatically
+        generates prototypes so functions can be called before they're defined.
+
+        Args:
+            source: The sketch source code
+
+        Returns:
+            List of function prototype strings
+        """
+        import re
+
+        prototypes = []
+
+        # Remove comments to avoid matching function-like patterns in comments
+        # Remove single-line comments
+        source_no_comments = re.sub(r'//.*?$', '', source, flags=re.MULTILINE)
+        # Remove multi-line comments
+        source_no_comments = re.sub(r'/\*.*?\*/', '', source_no_comments, flags=re.DOTALL)
+
+        # Pattern to match function definitions
+        # Matches: return_type function_name(parameters) {
+        # This pattern captures:
+        # - Optional inline/static keywords
+        # - Return type (including pointer types with *)
+        # - Function name
+        # - Parameters (including default values)
+        function_pattern = r'^\s*(?:inline\s+|static\s+)?([a-zA-Z_][\w\s\*&:<>,]*?)\s+([a-zA-Z_]\w*)\s*\((.*?)\)\s*(?:\{|$)'
+
+        # Find all function definitions
+        for match in re.finditer(function_pattern, source_no_comments, re.MULTILINE):
+            return_type = match.group(1).strip()
+            function_name = match.group(2).strip()
+            parameters = match.group(3).strip()
+
+            # Skip setup() and loop() - these are special Arduino functions
+            if function_name in ('setup', 'loop'):
+                continue
+
+            # Skip if this looks like a class method definition (has :: in return type)
+            if '::' in return_type:
+                continue
+
+            # Skip preprocessor directives
+            if return_type.startswith('#'):
+                continue
+
+            # Skip if return type contains keywords that indicate this isn't a function
+            skip_keywords = ['class', 'struct', 'enum', 'typedef', 'namespace', 'if', 'while', 'for', 'switch']
+            if any(keyword in return_type for keyword in skip_keywords):
+                continue
+
+            # Build the prototype
+            prototype = f"{return_type} {function_name}({parameters});"
+            prototypes.append(prototype)
+
+        return prototypes
+
     def compile_sketch(self, fqbn: str, sketch: str, build_path: Optional[str] = None,
                        config: Optional[str] = None) -> int:
         """Compile a sketch for the requested board using avr-gcc."""
@@ -373,11 +434,18 @@ class ArduinoCLI:
             print(f"✗ Failed to prepare build directory: {exc}", file=sys.stderr)
             return 1
 
+        # Generate function prototypes
+        prototypes = self._generate_function_prototypes(source)
+
         # Create preprocessed sketch with Arduino wrappers
         cpp_file = build_dir / f"{sketch_file.stem}.cpp"
         try:
-            # Add Arduino.h include and wrap sketch code
-            cpp_content = '#include <Arduino.h>\n\n' + source
+            # Add Arduino.h include, function prototypes, and then the sketch code
+            cpp_content = '#include <Arduino.h>\n\n'
+            if prototypes:
+                cpp_content += '// Function prototypes\n'
+                cpp_content += '\n'.join(prototypes) + '\n\n'
+            cpp_content += source
             cpp_file.write_text(cpp_content, encoding="utf-8")
         except Exception as exc:
             print(f"✗ Failed to create preprocessed sketch: {exc}", file=sys.stderr)

--- a/test_prototypes.ino
+++ b/test_prototypes.ino
@@ -1,0 +1,71 @@
+// Test sketch to verify function prototype generation
+// This sketch has functions called before they're defined
+
+void setup() {
+  Serial.begin(9600);
+  calibrateSensors();
+}
+
+void loop() {
+  if (Serial.available() > 0) {
+    char cmd = Serial.read();
+
+    switch (cmd) {
+      case '1':
+        testRawSensorReadings();
+        break;
+      case '2':
+        testThresholdDetection();
+        break;
+      case '3':
+        testLightOutputs();
+        break;
+      case '4':
+        testCalibration();
+        break;
+      case '5':
+        testFullSystem();
+        break;
+      case '6':
+        continuousMonitor();
+        break;
+      case '7':
+        displayBaselines();
+        break;
+    }
+  }
+}
+
+// Function definitions below (called before defined)
+
+void calibrateSensors() {
+  Serial.println("Calibrating sensors...");
+}
+
+void testRawSensorReadings() {
+  Serial.println("Testing raw sensor readings...");
+}
+
+void testThresholdDetection() {
+  Serial.println("Testing threshold detection...");
+}
+
+void testLightOutputs() {
+  Serial.println("Testing light outputs...");
+}
+
+void testCalibration() {
+  Serial.println("Testing calibration...");
+}
+
+void testFullSystem() {
+  Serial.println("Testing full system...");
+}
+
+void continuousMonitor() {
+  Serial.println("Continuous monitoring...");
+}
+
+void displayBaselines() {
+  Serial.println("Displaying baselines...");
+}


### PR DESCRIPTION
This fixes compilation errors where functions are called before they're defined. The official Arduino IDE automatically generates forward declarations for all user-defined functions, and this implementation replicates that behavior.

Changes:
- Added _generate_function_prototypes() method that parses Arduino sketches and extracts function signatures
- Automatically generates forward declarations for all functions except setup() and loop() (which are special Arduino functions)
- Inserts prototypes after #include <Arduino.h> in the preprocessed file
- Handles various edge cases: comments, class methods, preprocessor directives

The prototype generator uses regex to find function definitions and:
- Removes comments to avoid false matches
- Skips setup() and loop() functions
- Filters out class methods, preprocessor directives, and control structures
- Generates proper forward declarations with return types and parameters

Fixes compilation errors like:
  error: 'calibrateSensors' was not declared in this scope error: 'testRawSensorReadings' was not declared in this scope

Added test sketch (test_prototypes.ino) to verify the functionality.