### PR TITLE
Fix pin usage not updating when files are opened

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -868,6 +868,8 @@ void loop() {
 
         self.add_recent_file(path)
         self.status_bar.set_status(f"Opened {path.name}")
+        # Explicitly update pin usage after opening file
+        self.update_pin_usage()
         QTimer.singleShot(2000, lambda: self.status_bar.set_status("Ready"))
 
         self.status_bar.set_status(f"Saved {path.name}")

--- a/arduino_ide/ui/pin_usage_widget.py
+++ b/arduino_ide/ui/pin_usage_widget.py
@@ -298,11 +298,14 @@ class PinUsageWidget(QWidget):
 
                 # Try to infer description from variable name if not already set
                 if pin != resolved_pin and not pin_info[resolved_pin]['descriptions']:
-                    # Convert camelCase or snake_case to readable
-                    desc = re.sub(r'([A-Z])', r' \1', pin).strip()
-                    desc = desc.replace('_', ' ').replace('Pin', '').replace('pin', '').strip()
-                    if desc and desc.lower() not in ['led', 'builtin']:
-                        pin_info[resolved_pin]['descriptions'].append(desc.lower())
+                    # Convert snake_case and remove common pin suffixes
+                    desc = pin.replace('_PIN', '').replace('_pin', '').replace('_', ' ')
+                    # Handle camelCase: add space before uppercase letter that follows lowercase
+                    desc = re.sub(r'([a-z])([A-Z])', r'\1 \2', desc)
+                    # Clean up and normalize
+                    desc = desc.replace('  ', ' ').strip().lower()
+                    if desc and desc not in ['led', 'builtin']:
+                        pin_info[resolved_pin]['descriptions'].append(desc)
 
         return pin_info
 


### PR DESCRIPTION
Two issues fixed:
1. Pin usage widget was not updating when .ino files were opened, only when text was typed. Now explicitly calls update_pin_usage() after files are opened.

2. Pin descriptions were broken with extra spaces between characters (e.g., "s e n s o r  w e s t" instead of "sensor west"). Fixed the regex logic to properly handle snake_case and camelCase variable names.

Now when opening Arduino sketches with pin definitions, the pin usage panel correctly displays all used pins with proper descriptions.