### PR TITLE
Show all available pins from selected board in pin usage widget

### DIFF
--- a/arduino_ide/ui/board_panel.py
+++ b/arduino_ide/ui/board_panel.py
@@ -142,6 +142,14 @@ class BoardPanel(QWidget):
         """Set connected port"""
         self.port_label.setText(port)
 
+    def set_board(self, board):
+        """Set the current board
+
+        Args:
+            board: Board object from arduino_ide.models.board
+        """
+        self.pin_usage_widget.set_board(board)
+
     def update_pin_usage(self, code_text):
         """Update pin usage overview from code
 

--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -1399,8 +1399,13 @@ void loop() {
         """Handle board selection change"""
         self.status_bar.set_status(f"Board changed to: {board_name}")
         self.console_panel.append_output(f"Selected board: {board_name}")
-        # Update board panel
+        # Get the Board object
+        board = self._get_selected_board()
+        # Update board panel with board name
         self.board_panel.update_board_info(board_name)
+        # Update pin usage widget with Board object
+        if board:
+            self.board_panel.set_board(board)
         # Update status display with new board specs
         self.status_display.update_board(board_name)
         # Update status bar
@@ -1811,6 +1816,10 @@ void loop() {
         """Initialize status bar with default values"""
         # Set initial board
         self.status_bar.set_board(self.board_selector.currentText())
+        # Set initial board for pin widget
+        board = self._get_selected_board()
+        if board:
+            self.board_panel.set_board(board)
 
         # Set initial port
         current_port = self.port_selector.currentText()

--- a/test_pin_logic.py
+++ b/test_pin_logic.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+Test script to verify pin generation logic
+"""
+
+from arduino_ide.models.board import DEFAULT_BOARDS
+
+def test_pin_generation():
+    """Test that pins are generated correctly for each board"""
+
+    print("Testing pin generation for all default boards:\n")
+
+    for board in DEFAULT_BOARDS:
+        print(f"Board: {board.name}")
+        print(f"  Architecture: {board.architecture}")
+        print(f"  Digital pins: {board.specs.digital_pins}")
+        print(f"  Analog pins: {board.specs.analog_pins}")
+
+        # Generate pins like the widget does
+        digital_pins = [f'D{i}' for i in range(board.specs.digital_pins)]
+        analog_pins = [f'A{i}' for i in range(board.specs.analog_pins)]
+        all_pins = digital_pins + analog_pins
+
+        print(f"  Total pins: {len(all_pins)}")
+        print(f"  Digital: {', '.join(digital_pins[:5])}{'...' if len(digital_pins) > 5 else ''}")
+        print(f"  Analog: {', '.join(analog_pins)}")
+        print()
+
+if __name__ == "__main__":
+    test_pin_generation()


### PR DESCRIPTION
Updated the pin usage widget to display all available pins from the currently selected board, not just a hardcoded set of Arduino Uno pins.

Changes:
- PinUsageWidget now stores current board reference and uses board specs
- get_available_pins() generates pins based on board's digital_pins and analog_pins
- BoardPanel.set_board() passes Board object to pin widget
- MainWindow passes Board object when board changes or on initialization
- All available pins are now shown (not just 5) as "AVAILABLE"

This fixes the issue where only Arduino Uno pins were shown regardless of the selected board. Now users will see:
- Arduino Uno: 20 pins (14 digital + 6 analog)
- Arduino Mega 2560: 70 pins (54 digital + 16 analog)
- ESP32 Dev Module: 52 pins (34 digital + 18 analog)
- Arduino Nano 33 IoT: 22 pins (14 digital + 8 analog)

Files modified:
- arduino_ide/ui/pin_usage_widget.py
- arduino_ide/ui/board_panel.py
- arduino_ide/ui/main_window.py

Test script added to verify pin generation logic for all boards.