### PR TITLE
Fix pin widget bug: each pin was replacing the previous one

### DIFF
--- a/arduino_ide/ui/pin_usage_widget.py
+++ b/arduino_ide/ui/pin_usage_widget.py
@@ -94,13 +94,16 @@ class PinUsageWidget(QWidget):
             description: Optional description (e.g., "sensor", "LED")
             conflict: Whether this pin has a conflict
         """
-        # Remove empty state if present
-        layout_count = self.pin_layout.count()
-        if layout_count == 2:  # Header + empty state + stretch
-            item = self.pin_layout.takeAt(0)
-            if item.widget():
-                item.widget().deleteLater()
-                print(f"[ADD_PIN DEBUG] Removed empty state for first pin {pin_name}")
+        # Remove empty state if present (check if first widget is a QLabel, not a QFrame)
+        if self.pin_layout.count() > 1:
+            first_item = self.pin_layout.itemAt(0)
+            if first_item and first_item.widget():
+                # Empty state is a QLabel, pin items are QFrame
+                widget = first_item.widget()
+                if isinstance(widget, QLabel):
+                    self.pin_layout.takeAt(0)
+                    widget.deleteLater()
+                    print(f"[ADD_PIN DEBUG] Removed empty state label for first pin {pin_name}")
 
         # Determine icon based on status
         if conflict:


### PR DESCRIPTION
The add_pin() method was incorrectly removing the previous pin instead of just the empty state label. It checked if layout count == 2, but that's true for both 'empty state + stretch' AND 'one pin + stretch'.

Fixed by checking if the first widget is a QLabel (empty state) vs QFrame (pin). Now all 20 pins display correctly instead of just the last one (A5).