### PR TITLE
Remove Variable Watch widget and clean up Status Display

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -17,7 +17,6 @@ from arduino_ide.ui.serial_monitor import SerialMonitor
 from arduino_ide.ui.board_panel import BoardPanel
 from arduino_ide.ui.project_explorer import ProjectExplorer
 from arduino_ide.ui.console_panel import ConsolePanel
-from arduino_ide.ui.variable_watch import VariableWatch
 from arduino_ide.ui.status_display import StatusDisplay
 from arduino_ide.ui.context_panel import ContextPanel
 from arduino_ide.ui.plotter_panel import PlotterPanel
@@ -578,13 +577,11 @@ class MainWindow(QMainWindow):
         # --- RIGHT COLUMN (Normal widgets, NOT docks) ---
         # Create right-side panel widgets
         self.board_panel = BoardPanel()
-        self.variable_watch = VariableWatch()
         self.status_display = StatusDisplay()
         self.context_panel = ContextPanel()
 
         # Add widgets to right column layout (NOT as dock widgets)
         self.right_column_layout.addWidget(self.board_panel)
-        self.right_column_layout.addWidget(self.variable_watch)
         self.right_column_layout.addWidget(self.status_display)
         self.right_column_layout.addWidget(self.context_panel)
         self.right_column_layout.addStretch()

--- a/arduino_ide/ui/status_display.py
+++ b/arduino_ide/ui/status_display.py
@@ -576,28 +576,6 @@ class StatusDisplay(QWidget):
         self.ram_bar = MemoryBar("Dynamic Memory (RAM)")
         main_layout.addWidget(self.ram_bar)
 
-        # Board info
-        board_group = QGroupBox("Board Information")
-        board_group.setFont(QFont("Arial", 9, QFont.Bold))
-        board_layout = QVBoxLayout()
-
-        self.board_name_label = QLabel("Board: Arduino Uno")
-        self.board_name_label.setFont(QFont("Consolas", 9))
-        board_layout.addWidget(self.board_name_label)
-
-        board_group.setLayout(board_layout)
-        main_layout.addWidget(board_group)
-
-        # Info note
-        info_label = QLabel(
-            "✓ High-accuracy estimation (99%+ accurate)\n"
-            "Based on actual compiler memory footprint analysis"
-        )
-        info_label.setFont(QFont("Arial", 8))
-        info_label.setStyleSheet("color: #4CAF50; padding: 10px; background: #1e1e1e; border-radius: 5px;")
-        info_label.setWordWrap(True)
-        main_layout.addWidget(info_label)
-
         main_layout.addStretch()
 
         # Initialize with default board
@@ -713,9 +691,6 @@ class StatusDisplay(QWidget):
         self.board_architecture = specs.get(
             "architecture", CodeAnalyzer.detect_architecture(board_name)
         )
-
-        # Update board name display
-        self.board_name_label.setText(f"Board: {board_name}")
 
         # Re-analyze current code with new board specs
         if self.current_code:


### PR DESCRIPTION
- Remove Variable Watch widget from right column to allow Pin Usage Monitor to be taller
- Remove board information field from Real Time Usage Monitor
- Remove accuracy estimation comment from Real Time Usage Monitor