### PR TITLE
Fix preprocessor to handle old C-style typedef syntax

### DIFF
--- a/arduino-cli
+++ b/arduino-cli
@@ -403,10 +403,12 @@ class ArduinoCLI:
             r'^\s*(?:typedef\s+)?struct\s+([a-zA-Z_]\w*)',
             r'^\s*(?:typedef\s+)?class\s+([a-zA-Z_]\w*)',
             r'^\s*(?:typedef\s+)?enum\s+([a-zA-Z_]\w*)',
+            # Old C-style: typedef struct { ... } Name;
+            r'^\s*typedef\s+(?:struct|class|enum)\s*\{[^}]*\}\s*([a-zA-Z_]\w*)\s*;',
         ]
 
         for pattern in type_patterns:
-            for match in re.finditer(pattern, type_definitions, re.MULTILINE):
+            for match in re.finditer(pattern, type_definitions, re.MULTILINE | re.DOTALL):
                 custom_types.add(match.group(1))
 
         return custom_types
@@ -474,11 +476,13 @@ class ArduinoCLI:
             r'^\s*(?:typedef\s+)?struct\s+([a-zA-Z_]\w*)',
             r'^\s*(?:typedef\s+)?class\s+([a-zA-Z_]\w*)',
             r'^\s*(?:typedef\s+)?enum\s+([a-zA-Z_]\w*)',
+            # Old C-style: typedef struct { ... } Name;
+            r'^\s*typedef\s+(?:struct|class|enum)\s*\{[^}]*\}\s*([a-zA-Z_]\w*)\s*;',
             r'^\s*typedef\s+.*?\s+([a-zA-Z_]\w*)\s*;',
         ]
 
         for pattern in type_patterns:
-            for match in re.finditer(pattern, source_no_comments, re.MULTILINE):
+            for match in re.finditer(pattern, source_no_comments, re.MULTILINE | re.DOTALL):
                 custom_types.add(match.group(1))
 
         # Pattern to match function definitions

--- a/test_old_style_typedef.ino
+++ b/test_old_style_typedef.ino
@@ -1,0 +1,63 @@
+/*
+ * Test old C-style typedef syntax compatibility
+ * This should compile without errors after the preprocessor fix
+ */
+
+// Pin definitions
+const int SENSOR_PIN = A0;
+const int RELAY_PIN = 5;
+
+// Forward declarations (appear before type definitions)
+void initializeControl(ControlStruct& ctrl);
+void updateControl(ControlStruct& ctrl);
+const char* getStatus(const ControlStruct& ctrl);
+
+// Old C-style typedef (name after closing brace)
+typedef struct {
+  const char* label;
+  int sensorPin;
+  int relayPin;
+  int currentState;
+  int lastReading;
+  unsigned long lastDebounceTime;
+} ControlStruct;
+
+ControlStruct myControl = {
+  "Test Control",
+  SENSOR_PIN,
+  RELAY_PIN,
+  0,
+  0,
+  0
+};
+
+void setup() {
+  Serial.begin(9600);
+  pinMode(myControl.relayPin, OUTPUT);
+  initializeControl(myControl);
+  Serial.println("System Ready!");
+}
+
+void loop() {
+  updateControl(myControl);
+}
+
+void initializeControl(ControlStruct& ctrl) {
+  ctrl.lastDebounceTime = millis();
+  Serial.print("Initialized: ");
+  Serial.println(ctrl.label);
+}
+
+void updateControl(ControlStruct& ctrl) {
+  int reading = analogRead(ctrl.sensorPin);
+
+  if (reading != ctrl.lastReading) {
+    ctrl.lastDebounceTime = millis();
+  }
+
+  ctrl.lastReading = reading;
+}
+
+const char* getStatus(const ControlStruct& ctrl) {
+  return ctrl.label;
+}


### PR DESCRIPTION
The preprocessor now correctly recognizes type names from old C-style typedef declarations like:
  typedef struct { ... } TypeName;

Previously, only modern syntax (struct TypeName { ... }) was recognized. This caused compilation errors when forward declarations using these types appeared before the typedef definition, because the preprocessor couldn't identify and remove the forward declarations.

Changes:
- Updated _extract_custom_type_names() to match old-style typedef syntax
- Updated _generate_function_prototypes() with same pattern
- Added regex pattern: typedef (struct|class|enum) {...} TypeName;
- Added test case: test_old_style_typedef.ino

This makes the Modern IDE more forgiving, matching Arduino IDE 1.8 behavior for legacy code.