### PR TITLE
Move code snippets library from right panel to Tools menu dialog

### DIFF
--- a/arduino_ide/ui/main_window.py
+++ b/arduino_ide/ui/main_window.py
@@ -27,7 +27,7 @@ from arduino_ide.ui.quick_actions_panel import QuickActionsPanel
 from arduino_ide.ui.library_manager_dialog import LibraryManagerDialog
 from arduino_ide.ui.board_manager_dialog import BoardManagerDialog
 from arduino_ide.ui.find_replace_dialog import FindReplaceDialog
-from arduino_ide.ui.snippets_panel import SnippetsPanel
+from arduino_ide.ui.snippets_panel import SnippetsLibraryDialog
 from arduino_ide.services.theme_manager import ThemeManager
 from arduino_ide.services.library_manager import LibraryManager
 from arduino_ide.services.board_manager import BoardManager
@@ -403,6 +403,13 @@ class MainWindow(QMainWindow):
         library_action.triggered.connect(self.open_library_manager)
         tools_menu.addAction(library_action)
 
+        tools_menu.addSeparator()
+
+        snippets_action = QAction("Code Snippets...", self)
+        snippets_action.setShortcut(Qt.CTRL | Qt.SHIFT | Qt.Key_K)
+        snippets_action.triggered.connect(self.show_snippets_library)
+        tools_menu.addAction(snippets_action)
+
         # View Menu
         view_menu = menubar.addMenu("&View")
 
@@ -581,16 +588,11 @@ class MainWindow(QMainWindow):
         self.board_panel = BoardPanel()
         self.status_display = StatusDisplay()
         self.context_panel = ContextPanel()
-        self.snippets_panel = SnippetsPanel()
-
-        # Connect snippets panel to insert snippets
-        self.snippets_panel.snippet_insert_requested.connect(self.insert_snippet)
 
         # Add widgets to right column layout (NOT as dock widgets)
         self.right_column_layout.addWidget(self.board_panel)
         self.right_column_layout.addWidget(self.status_display)
         self.right_column_layout.addWidget(self.context_panel)
-        self.right_column_layout.addWidget(self.snippets_panel)
         self.right_column_layout.addStretch()
 
         # --- BOTTOM TABS (Normal widgets in tabs, NOT docks) ---
@@ -1751,6 +1753,19 @@ void loop() {
         dialog.exec_()
 
         self.status_bar.set_status("Ready")
+
+    def show_snippets_library(self):
+        """Show code snippets library dialog"""
+        # Create snippets dialog if it doesn't exist
+        if not hasattr(self, 'snippets_dialog') or self.snippets_dialog is None:
+            self.snippets_dialog = SnippetsLibraryDialog(self)
+            # Connect snippet insert signal
+            self.snippets_dialog.snippet_insert_requested.connect(self.insert_snippet)
+
+        # Show the dialog
+        self.snippets_dialog.show()
+        self.snippets_dialog.raise_()
+        self.snippets_dialog.activateWindow()
 
     def on_board_selected_from_manager(self, fqbn: str):
         """Handle board selection from board manager"""

--- a/arduino_ide/ui/snippets_panel.py
+++ b/arduino_ide/ui/snippets_panel.py
@@ -1,10 +1,10 @@
 """
-Snippets panel for browsing and inserting code snippets
+Snippets library dialog for browsing and inserting code snippets
 """
 
 from PySide6.QtWidgets import (
-    QWidget, QVBoxLayout, QHBoxLayout, QTreeWidget, QTreeWidgetItem,
-    QTextEdit, QPushButton, QLineEdit, QLabel, QSplitter
+    QDialog, QVBoxLayout, QHBoxLayout, QTreeWidget, QTreeWidgetItem,
+    QTextEdit, QPushButton, QLineEdit, QLabel, QSplitter, QDialogButtonBox
 )
 from PySide6.QtCore import Qt, Signal
 from PySide6.QtGui import QFont
@@ -12,36 +12,25 @@ from PySide6.QtGui import QFont
 from arduino_ide.services.snippets_manager import SnippetsManager
 
 
-class SnippetsPanel(QWidget):
-    """Panel for browsing and inserting code snippets"""
+class SnippetsLibraryDialog(QDialog):
+    """Dialog for browsing and inserting code snippets"""
 
     snippet_insert_requested = Signal(object)  # Emits Snippet object
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self.snippets_manager = SnippetsManager()
+        self.setWindowTitle("Code Snippets Library")
+        self.setModal(False)
+        self.resize(700, 600)
         self.setup_ui()
         self.populate_snippets()
 
     def setup_ui(self):
         """Setup the UI"""
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(5)
-
-        # Title
-        title_label = QLabel("Code Snippets")
-        title_label.setStyleSheet("""
-            QLabel {
-                font-weight: bold;
-                font-size: 14px;
-                padding: 8px;
-                background-color: #2D2D30;
-                color: #FFFFFF;
-                border-bottom: 1px solid #3E3E42;
-            }
-        """)
-        layout.addWidget(title_label)
+        layout.setContentsMargins(10, 10, 10, 10)
+        layout.setSpacing(10)
 
         # Search box
         search_layout = QHBoxLayout()
@@ -140,14 +129,28 @@ class SnippetsPanel(QWidget):
 
         layout.addWidget(splitter)
 
-        # Insert button
+        # Buttons
         button_layout = QHBoxLayout()
-        button_layout.setContentsMargins(5, 5, 5, 5)
+        button_layout.addStretch()
 
         self.insert_button = QPushButton("Insert Snippet")
         self.insert_button.clicked.connect(self.insert_selected_snippet)
         self.insert_button.setEnabled(False)
-        self.insert_button.setStyleSheet("""
+        self.insert_button.setDefault(True)
+        button_layout.addWidget(self.insert_button)
+
+        close_button = QPushButton("Close")
+        close_button.clicked.connect(self.close)
+        button_layout.addWidget(close_button)
+
+        layout.addLayout(button_layout)
+
+        # Apply dialog styling
+        self.setStyleSheet("""
+            QDialog {
+                background-color: #1E1E1E;
+                color: #FFFFFF;
+            }
             QPushButton {
                 background-color: #0E639C;
                 color: #FFFFFF;
@@ -167,9 +170,6 @@ class SnippetsPanel(QWidget):
                 color: #858585;
             }
         """)
-        button_layout.addWidget(self.insert_button)
-
-        layout.addLayout(button_layout)
 
     def populate_snippets(self):
         """Populate the tree with snippets"""


### PR DESCRIPTION
Changes:
- Converted SnippetsPanel widget into SnippetsLibraryDialog
- Removed snippets panel from right column in main window
- Added "Code Snippets..." menu item to Tools menu (Ctrl+Shift+K)
- Dialog opens non-modally, allowing users to browse snippets while coding
- Added Insert and Close buttons for better dialog UX
- Maintains snippet insertion functionality with cursor positioning

The snippets library is now more accessible and doesn't take up permanent screen space in the right panel.