### PR TITLE
Fix CompletionDelegate paint error with QStyle constants

### DIFF
--- a/arduino_ide/ui/code_editor.py
+++ b/arduino_ide/ui/code_editor.py
@@ -5,7 +5,8 @@ Code editor with syntax highlighting and IntelliSense
 from PySide6.QtWidgets import (
     QPlainTextEdit, QWidget, QTextEdit, QCompleter, QLabel, QHBoxLayout,
     QVBoxLayout, QScrollBar, QToolTip, QMenu, QDialog, QFormLayout, QPushButton,
-    QListWidget, QListWidgetItem, QTextBrowser, QDialogButtonBox, QStyledItemDelegate
+    QListWidget, QListWidgetItem, QTextBrowser, QDialogButtonBox, QStyledItemDelegate,
+    QStyle
 )
 from PySide6.QtCore import Qt, QRect, QSize, Signal, QStringListModel, QTimer, QPoint, QAbstractListModel, QModelIndex
 from PySide6.QtGui import (
@@ -585,9 +586,9 @@ class CompletionDelegate(QStyledItemDelegate):
             return
 
         # Set background color
-        if option.state & self.State_Selected:
+        if option.state & QStyle.State_Selected:
             painter.fillRect(option.rect, QColor("#094771"))  # Selected blue
-        elif option.state & self.State_MouseOver:
+        elif option.state & QStyle.State_MouseOver:
             painter.fillRect(option.rect, QColor("#2A2D2E"))  # Hover gray
         else:
             painter.fillRect(option.rect, QColor("#1E1E1E"))  # Background


### PR DESCRIPTION
The CompletionDelegate's paint method was trying to access State_Selected and State_MouseOver as instance attributes (self.State_Selected), but these are Qt constants that need to be accessed from QStyle class.

Fixed by:
- Adding QStyle to imports from PySide6.QtWidgets
- Changing self.State_Selected to QStyle.State_Selected
- Changing self.State_MouseOver to QStyle.State_MouseOver

This resolves the AttributeError that was occurring when the autocomplete popup was being painted.