### PR TITLE
Fix regex pattern syntax error in SnippetSheet causing crash

### DIFF
--- a/android/android-studio/app/src/main/java/com/arduino/ide/mobile/snippets/SnippetSheet.kt
+++ b/android/android-studio/app/src/main/java/com/arduino/ide/mobile/snippets/SnippetSheet.kt
@@ -226,7 +226,7 @@ private fun SnippetActions(onAddUserSnippet: (String, String, String) -> Unit) {
 }
 
 private fun snippetPreview(body: String): AnnotatedString {
-    val regex = Regex("\\$\\{(\\d+):([^}]*)}|\\$(\\d+)|\\$0")
+    val regex = Regex("\\$\\{(\\d+):([^}]*)\\}|\\$(\\d+)|\\$0")
     return buildAnnotatedString {
         var cursor = 0
         regex.findAll(body).forEach { match ->


### PR DESCRIPTION
Escape the closing brace in the snippet placeholder regex pattern. The unescaped `}` after `[^}]*` caused a PatternSyntaxException on Android's Java regex engine.

https://claude.ai/code/session_011AnoA92d1okczsnJGgDc9V